### PR TITLE
ci(actions): disable matrix fail-fast to allow independent OS test co…

### DIFF
--- a/.github/workflows/multi-os-ci.yml
+++ b/.github/workflows/multi-os-ci.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      # Prevents one OS job failure (e.g., Ubuntu) from canceling all matrix jobs
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
 


### PR DESCRIPTION
…mpletion

Adds `fail-fast: false` to the Multi-OS CI workflow so that macOS and Windows tests continue running even if Ubuntu fails. This ensures all platform results are visible in a single run and simplifies cross-platform debugging.