### PR TITLE
feat(config): add configurable transformer server URL across runtime and templates

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -48,6 +48,13 @@ pub fn build_cli() -> ArgMatches {
                             .help("LLM model to use")
                     )
                     .arg(
+                        Arg::new("url")
+                            .long("url")
+                            .help("Custom transformer server URL (HTTPS preferred)")
+                            .required(false)
+                            .value_name("URL")
+                    )
+                    .arg(
                         Arg::new("token")
                             .long("token")
                             .value_name("TOKEN")
@@ -127,6 +134,13 @@ pub fn build_cli() -> ArgMatches {
                                 .help("LLM model identifier (e.g., gpt-4o, mistral)")
                                 .required(true)
                                 .value_name("MODEL")
+                        )
+                        .arg(
+                            Arg::new("url")
+                                .long("url")
+                                .help("Custom transformer server URL (HTTPS preferred)")
+                                .required(false)
+                                .value_name("URL")
                         )
                         .arg(
                             Arg::new("token")

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -25,6 +25,9 @@ pub struct Profile {
     pub model: String,
 
     #[serde(default)]
+    pub url: Option<String>, 
+
+    #[serde(default)]
     pub token: Option<String>,
 
     #[serde(default = "default_timeout")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,11 @@
 //! # async {
 //! // For the Ollama API:
 //! // Provide the model name, prompt, and a timeout (in seconds).
-//! let ollama_response = ollama_send_request("model_name", "Your prompt here", 60).await;
+//! let ollama_response = ollama_send_request("url", "model_name", "Your prompt here", 60).await;
 //!
 //! // For the OpenAI API:
 //! // Provide the model name, prompt, timeout (in seconds), and your API token.
-//! let openai_response = openai_send_request("model_name", "Your prompt here", 60, "your_token_here").await;
+//! let openai_response = openai_send_request("url", "model_name", "Your prompt here", 60, "your_token_here").await;
 //! # };
 //! ```
 //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ async fn main() {
         // Begin: Argument assignments
         let mut server = String::new();
         let mut model = String::new();
+        let mut url = String::new();
         let mut token = String::new();
         let mut timeout_in_sec: u64 = 60; // Default
 
@@ -46,6 +47,8 @@ async fn main() {
                     model = profile.model.clone();
                     token = profile.token.clone().unwrap_or_default();
                     timeout_in_sec = profile.timeout_in_sec;
+                    // Updated URL assignment logic:
+                    url = profile.url.clone().unwrap_or_default();
                     println!("Using profile '{}'", profile_name);
                 } else {
                     eprintln!("Profile '{}' not found.", profile_name);
@@ -69,6 +72,7 @@ async fn main() {
                         model = profile.model.clone();
                         token = profile.token.clone().unwrap_or_default();
                         timeout_in_sec = profile.timeout_in_sec;
+                        url = profile.url.clone().unwrap_or_default();
                         println!("Using default profile '{}'", default_profile_name);
                     }
                 }
@@ -90,6 +94,17 @@ async fn main() {
 
         if let Some(timeout_arg) = sub_m.get_one::<String>("timeout_in_sec") {
             timeout_in_sec = timeout_arg.parse::<u64>().unwrap_or(60);
+        }
+
+        // Final URL fallback based on resolved server
+        if url.is_empty() {
+            url = if server == "ollama" {
+                "http://localhost:11434/api/generate".to_string()
+            } else if server == "openai" {
+                "https://api.openai.com/v1/chat/completions".to_string()
+            } else {
+                String::new()
+            };
         }
 
         // End: Argument assignments
@@ -118,7 +133,7 @@ async fn main() {
 
         if server == "ollama" {
             // Send request to Ollama and `await` the LLM response
-            match cargo_ai::ollama_send_request(&model, &structured_prompt, timeout_in_sec, json_schema_value()).await {
+            match cargo_ai::ollama_send_request(&url, &model, &structured_prompt, timeout_in_sec, json_schema_value()).await {
                 Ok(r) => {
                     response.push_str(&r);
                 },
@@ -143,7 +158,7 @@ async fn main() {
         });
 
             // Send request to OpenAI and `await` the LLM response
-            match cargo_ai::openai_send_request(&model, &structured_prompt, timeout_in_sec, &token, fmt).await {
+            match cargo_ai::openai_send_request(&url, &model, &structured_prompt, timeout_in_sec, &token, fmt).await {
                 Ok(r) => response.push_str(&r),
                 Err(e) => {
                     println!("We have an error {}", e);
@@ -225,6 +240,7 @@ async fn main() {
             let name = add_m.get_one::<String>("name").expect("Profile name is required");
             let server = add_m.get_one::<String>("server").expect("Server is required");
             let model = add_m.get_one::<String>("model").expect("Model is required");
+            let url = add_m.get_one::<String>("url").map(String::as_str).unwrap_or("(none)");
             let token = add_m.get_one::<String>("token").map(String::as_str).unwrap_or("(none)");
             let description = add_m.get_one::<String>("description").map(String::as_str).unwrap_or("(none)");
 
@@ -232,6 +248,7 @@ async fn main() {
             println!("  Name: {}", name);
             println!("  Server: {}", server);
             println!("  Model: {}", model);
+            println!("  URL: {}", url);
             println!("  Token: {}", token);
             println!("  Description: {}", description);
 
@@ -240,6 +257,7 @@ async fn main() {
                 name: name.to_string(),
                 server: server.to_string(),
                 model: model.to_string(),
+                url: if url == "(none)" { None } else { Some(url.to_string()) },
                 token: if token == "(none)" { None } else { Some(token.to_string()) },
                 timeout_in_sec: 60, // default for now
                 description: if description == "(none)" { None } else { Some(description.to_string()) },

--- a/src/ollama_api_client.rs
+++ b/src/ollama_api_client.rs
@@ -1,7 +1,6 @@
 // External Crates
 use reqwest::ClientBuilder; // HTTP client builder
 use serde::{Deserialize, Serialize}; // Data format (e.g.,JSON, TOML) (de)serialization
-use std::env;
 use std::time::Duration; // Duration for timeout handling // for overriding the API URL in tests
 
 // Request as per Ollama API Guide
@@ -29,11 +28,13 @@ struct Response {
 }
 
 pub async fn send_request(
+    url: &String,
     model: &String,
     prompt: &String,
     timeout_in_sec: u64,
     format: serde_json::Value,
 ) -> Result<String, Box<dyn std::error::Error>> {
+
     let request = Request {
         model: model.clone(),
         prompt: prompt.clone(),
@@ -46,12 +47,8 @@ pub async fn send_request(
         .timeout(Duration::from_secs(timeout_in_sec))
         .build()?; // 30 sec Default too short for some LLMs.
 
-    // Allow overriding Ollama API URL in tests via OLLAMA_API_URL env var
-    let api_url = env::var("OLLAMA_API_URL")
-        .unwrap_or_else(|_| "http://localhost:11434/api/generate".to_string());
-
     let http_resp = client
-        .post(&api_url)
+        .post(url)
         .json(&request)
         .send()
         .await?;
@@ -110,6 +107,7 @@ mod tests {
 
         // Execute the client against the mock
         let result = send_request(
+            &format!("{}{}", server.url().to_string(), mock_path),
             &"test-model".to_string(),
             &"test prompt".to_string(),
             5,

--- a/src/openai_api_client.rs
+++ b/src/openai_api_client.rs
@@ -44,6 +44,7 @@ pub struct Usage {
 }
 
 pub async fn send_request(
+    url: &String,
     model: &String,
     prompt: &String,
     timeout_in_sec: u64,
@@ -82,7 +83,7 @@ pub async fn send_request(
     // println!("OpenAI request JSON:\n{}", serde_json::to_string_pretty(&request)?);
 
     let http_resp = client
-        .post("https://api.openai.com/v1/chat/completions")
+        .post(url)
         .header("Authorization", format!("Bearer {}", token))
         .header("Content-Type", "application/json")
         .json(&request)

--- a/templates/src/args.rs
+++ b/templates/src/args.rs
@@ -39,6 +39,13 @@ pub fn build_cli() -> ArgMatches {
                 .global(true)
         )
         .arg(
+            Arg::new("url")
+                .long("url")
+                .help("Custom transformer server URL (HTTPS preferred)")
+                .global(true)
+                .value_name("URL")
+        )
+        .arg(
             Arg::new("token")
                 .long("token")
                 .help("API token")

--- a/templates/src/config/schema.rs
+++ b/templates/src/config/schema.rs
@@ -25,6 +25,9 @@ pub struct Profile {
     pub model: String,
 
     #[serde(default)]
+    pub url: Option<String>, 
+
+    #[serde(default)]
     pub token: Option<String>,
 
     #[serde(default = "default_timeout")]

--- a/templates/src/lib.rs
+++ b/templates/src/lib.rs
@@ -14,11 +14,11 @@
 //! # async {
 //! // For the Ollama API:
 //! // Provide the model name, prompt, and a timeout (in seconds).
-//! let ollama_response = ollama_send_request("model_name", "Your prompt here", 60).await;
+//! let ollama_response = ollama_send_request("url", "model_name", "Your prompt here", 60).await;
 //!
 //! // For the OpenAI API:
 //! // Provide the model name, prompt, timeout (in seconds), and your API token.
-//! let openai_response = openai_send_request("model_name", "Your prompt here", 60, "your_token_here").await;
+//! let openai_response = openai_send_request("url", "model_name", "Your prompt here", 60, "your_token_here").await;
 //! # };
 //! ```
 //!

--- a/templates/src/main.rs
+++ b/templates/src/main.rs
@@ -19,6 +19,7 @@ async fn main() {
     // Begin: Argument assignments
     let mut server = String::new();
     let mut model = String::new();
+    let mut url = String::new();
     let mut token = String::new();
     let mut timeout_in_sec: u64 = 60; // Default
 
@@ -68,12 +69,26 @@ async fn main() {
         model = model_arg.to_string();
     }
 
+    if let Some(url_arg) = cmd_args.get_one::<String>("url") {
+        url = url_arg.to_string();
+    }
+
     if let Some(cmd_token) = cmd_args.get_one::<String>("token") {
         token = cmd_token.to_string();
     }
 
     if let Some(timeout_arg) = cmd_args.get_one::<String>("timeout_in_sec") {
         timeout_in_sec = timeout_arg.parse::<u64>().unwrap_or(60);
+    }
+
+    if url.is_empty() {
+        url = if server == "ollama" {
+            "http://localhost:11434/api/generate".to_string()
+        } else if server == "openai" {
+            "https://api.openai.com/v1/chat/completions".to_string()
+        } else {
+            String::new()
+        };
     }
 
     let prompt = if let Some(prompt_arg) = cmd_args.get_one::<String>("prompt") {
@@ -106,7 +121,7 @@ async fn main() {
 
     if server == "ollama" {
         // Send request to Ollama and `await` the LLM response
-        match cargo_ai::ollama_send_request(&model, &structured_prompt, timeout_in_sec, json_schema_value()).await {
+        match cargo_ai::ollama_send_request(&url, &model, &structured_prompt, timeout_in_sec, json_schema_value()).await {
             Ok(r) => {
                 response.push_str(&r);
             },
@@ -131,7 +146,7 @@ async fn main() {
     });
 
         // Send request to OpenAI and `await` the LLM response
-        match cargo_ai::openai_send_request(&model, &structured_prompt, timeout_in_sec, &token, fmt).await {
+        match cargo_ai::openai_send_request(&url, &model, &structured_prompt, timeout_in_sec, &token, fmt).await {
             Ok(r) => response.push_str(&r),
             Err(e) => {
                 println!("We have an error {}", e);

--- a/templates/src/ollama_api_client.rs
+++ b/templates/src/ollama_api_client.rs
@@ -1,7 +1,6 @@
 // External Crates
 use reqwest::ClientBuilder; // HTTP client builder
 use serde::{Deserialize, Serialize}; // Data format (e.g.,JSON, TOML) (de)serialization
-use std::env;
 use std::time::Duration; // Duration for timeout handling // for overriding the API URL in tests
 
 // Request as per Ollama API Guide
@@ -29,11 +28,13 @@ struct Response {
 }
 
 pub async fn send_request(
+    url: &String,
     model: &String,
     prompt: &String,
     timeout_in_sec: u64,
     format: serde_json::Value,
 ) -> Result<String, Box<dyn std::error::Error>> {
+
     let request = Request {
         model: model.clone(),
         prompt: prompt.clone(),
@@ -46,12 +47,8 @@ pub async fn send_request(
         .timeout(Duration::from_secs(timeout_in_sec))
         .build()?; // 30 sec Default too short for some LLMs.
 
-    // Allow overriding Ollama API URL in tests via OLLAMA_API_URL env var
-    let api_url = env::var("OLLAMA_API_URL")
-        .unwrap_or_else(|_| "http://localhost:11434/api/generate".to_string());
-
     let http_resp = client
-        .post(&api_url)
+        .post(url)
         .json(&request)
         .send()
         .await?;
@@ -110,6 +107,7 @@ mod tests {
 
         // Execute the client against the mock
         let result = send_request(
+            &format!("{}{}", server.url().to_string(), mock_path),
             &"test-model".to_string(),
             &"test prompt".to_string(),
             5,

--- a/templates/src/openai_api_client.rs
+++ b/templates/src/openai_api_client.rs
@@ -44,6 +44,7 @@ pub struct Usage {
 }
 
 pub async fn send_request(
+    url: &String,
     model: &String,
     prompt: &String,
     timeout_in_sec: u64,
@@ -82,7 +83,7 @@ pub async fn send_request(
     // println!("OpenAI request JSON:\n{}", serde_json::to_string_pretty(&request)?);
 
     let http_resp = client
-        .post("https://api.openai.com/v1/chat/completions")
+        .post(url)
         .header("Authorization", format!("Bearer {}", token))
         .header("Content-Type", "application/json")
         .json(&request)


### PR DESCRIPTION
- Added `url` field to profile schema and config handling
- Added `--url` CLI flag (global and for profile add)
- Implemented correct precedence: CLI > profile > default
- Passed URL into Ollama and OpenAI client functions
- Updated library signatures and template agent main.rs to use URL
- Added fallback defaults per server type (Ollama/OpenAI)
- Synced changes across cargo-ai runtime, library, and templates