### PR TITLE
no panic on ollama

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,9 @@ async fn main() {
                     response.push_str(&r);
                 },
                 Err(e) => {
-                    println!("We have an error {}", e);
+                    eprintln!("Error communicating with Ollama: {}", e);
+                    eprintln!("Make sure Ollama is running at {}", url);
+                    std::process::exit(1);
                 }
             }
         } else if server == "openai" {
@@ -161,18 +163,23 @@ async fn main() {
             match cargo_ai::openai_send_request(&url, &model, &structured_prompt, timeout_in_sec, &token, fmt).await {
                 Ok(r) => response.push_str(&r),
                 Err(e) => {
-                    println!("We have an error {}", e);
+                    eprintln!("Error communicating with OpenAI: {}", e);
+                    std::process::exit(1);
                 }
             };
         }
 
         // println!("{server} Response: {response}");
-        
-        ai_cargo.set_response(response.clone());
+
+        if !ai_cargo.set_response(response.clone()) {
+            eprintln!("Error: Failed to parse LLM response as valid JSON");
+            eprintln!("Response was: {}", response);
+            std::process::exit(1);
+        }
 
 
-        // Get Output 
-        let output: Output = ai_cargo.get_response().unwrap();
+        // Get Output
+        let output: Output = ai_cargo.get_response().expect("Failed to get parsed response");
         // println!("Output: {:?}", output);
 
         // Get Actions


### PR DESCRIPTION
A panic was caused by improper error handling. Here's what was happening:

  The Problem:
  1. When running with -s ollama, if the Ollama server wasn't running or returned an error, the
   code caught the error but continued execution with an empty response
  2. At src/main.rs:175, the code called .unwrap() on get_response() which returned None
  (because the empty response couldn't be parsed as valid JSON)
  3. This caused the panic

  The Fix:
  I've updated the error handling in three places:

  1. src/main.rs:140-143 - When Ollama request fails, the program now exits immediately with a
  clear error message instead of continuing
  2. src/main.rs:165-167 - Same improvement for OpenAI requests
  3. src/main.rs:171-175 - Check if JSON parsing succeeded before trying to unwrap, and show
  what the invalid response was

  Now when you run with -s ollama, you'll get helpful error messages like:
  Error communicating with Ollama: <error details>
  Make sure Ollama is running at http://localhost:11434/api/generate

  Instead of a confusing panic. The program will exit cleanly with exit code 1 when something
  goes wrong.