### PR TITLE
CAI 162 thinking model issue

### DIFF
--- a/.agentcfg
+++ b/.agentcfg
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.9",
+  "version": "0.0.10",
   "prompt": "What is 2 + 2? Return the answer as a number.",
   "agent_schema": {
     "type": "object",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cargo-ai"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-ai"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 license = "MIT"
 description = "Build lightweight AI agents with Cargo. Powered by Rust. Declared in JSON."

--- a/adder_test.json
+++ b/adder_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.9",
+  "version": "0.0.10",
   "prompt": "What is 2 + 2? Return the answer as a number.",
   "agent_schema": {
     "type": "object",

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,9 @@ async fn main() {
                     response.push_str(&r);
                 },
                 Err(e) => {
-                    println!("We have an error {}", e);
+                    eprintln!("❌ Issue communicating with the AI server (Ollama).");
+                    eprintln!("Reason: {}\n", e);
+                    return;
                 }
             }
         } else if server == "openai" {
@@ -161,7 +163,9 @@ async fn main() {
             match cargo_ai::openai_send_request(&url, &model, &structured_prompt, timeout_in_sec, &token, fmt).await {
                 Ok(r) => response.push_str(&r),
                 Err(e) => {
-                    println!("We have an error {}", e);
+                    eprintln!("❌ Issue communicating with the AI server (OpenAI).");
+                    eprintln!("Reason: {}\n", e);
+                    return;
                 }
             };
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,14 +166,21 @@ async fn main() {
             };
         }
 
-        // println!("{server} Response: {response}");
-        
-        ai_cargo.set_response(response.clone());
+        // Attempt to conform the LLM response to the Output schema
+        if !ai_cargo.set_response(response.clone()) {
+            eprintln!("❌ LLM output did NOT conform to the required JSON schema.");
+            eprintln!("Raw output received from server:\n{}\n", response);
+            return; // Stop execution cleanly — do NOT continue to unwrap
+        }
 
-
-        // Get Output 
-        let output: Output = ai_cargo.get_response().unwrap();
-        // println!("Output: {:?}", output);
+        let output = match ai_cargo.get_response() {
+            Some(o) => o,
+            None => {
+                eprintln!("❌ Internal error: response was expected but missing.");
+                eprintln!("Raw output received from server:\n{}\n", response);
+                return;
+            }
+        };
 
         // Get Actions
         let actions = actions();

--- a/src/ollama_api_client.rs
+++ b/src/ollama_api_client.rs
@@ -10,6 +10,7 @@ struct Request {
     prompt: String,
     format: serde_json::Value,
     stream: bool,
+    think: bool,
     options: Options,
 }
 
@@ -25,6 +26,7 @@ struct Response {
     created_at: String,
     response: String,
     done: bool,
+    thinking: Option<String>,
 }
 
 pub async fn send_request(
@@ -40,6 +42,7 @@ pub async fn send_request(
         prompt: prompt.clone(),
         format: format.clone(),
         stream: false,
+        think: false,
         options: Options { temperature: crate::DEFAULT_TEMPERATURE}
     };
 
@@ -52,7 +55,7 @@ pub async fn send_request(
         .json(&request)
         .send()
         .await?;
-
+    
     let status = http_resp.status();
     let body_bytes = http_resp.bytes().await?;
 
@@ -69,7 +72,19 @@ pub async fn send_request(
         }
     };
 
-    Ok(reply.response)
+    // NOTE: Some Ollama "thinking" models may incorrectly place final output in the `thinking` field
+    // instead of the `response` field, even when `think` is set to false. This appears to be an
+    // Ollama-side issue. The logic below first checks `response`, and if empty, falls back to
+    // `thinking` to support current behavior.
+    let final_output = if !reply.response.is_empty() {
+        reply.response
+    } else if let Some(t) = reply.thinking {
+        t
+    } else {
+        return Err("Ollama returned neither response nor thinking fields.".into());
+    };
+
+    Ok(final_output)
 }
 
 #[cfg(test)]

--- a/templates/.agentcfg
+++ b/templates/.agentcfg
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.9",
+  "version": "0.0.10",
   "prompt": "What is 2 + 2? Return the answer as a number.",
   "agent_schema": {
     "type": "object",

--- a/templates/src/main.rs
+++ b/templates/src/main.rs
@@ -154,14 +154,21 @@ async fn main() {
         };
     }
 
-    // println!("{server} Response: {response}");
-    
-    ai_cargo.set_response(response.clone());
+            // Attempt to conform the LLM response to the Output schema
+        if !ai_cargo.set_response(response.clone()) {
+            eprintln!("❌ LLM output did NOT conform to the required JSON schema.");
+            eprintln!("Raw output received from server:\n{}\n", response);
+            return; // Stop execution cleanly — do NOT continue to unwrap
+        }
 
-
-    // Get Output 
-    let output: Output = ai_cargo.get_response().unwrap();
-    // println!("Output: {:?}", output);
+        let output = match ai_cargo.get_response() {
+            Some(o) => o,
+            None => {
+                eprintln!("❌ Internal error: response was expected but missing.");
+                eprintln!("Raw output received from server:\n{}\n", response);
+                return;
+            }
+        };
 
     // Get Actions
     let actions = actions();

--- a/templates/src/main.rs
+++ b/templates/src/main.rs
@@ -126,7 +126,9 @@ async fn main() {
                 response.push_str(&r);
             },
             Err(e) => {
-                println!("We have an error {}", e);
+                eprintln!("❌ Issue communicating with the AI server (Ollama).");
+                eprintln!("Reason: {}\n", e);
+                return;
             }
         }
     } else if server == "openai" {
@@ -149,7 +151,9 @@ async fn main() {
         match cargo_ai::openai_send_request(&url, &model, &structured_prompt, timeout_in_sec, &token, fmt).await {
             Ok(r) => response.push_str(&r),
             Err(e) => {
-                println!("We have an error {}", e);
+                eprintln!("❌ Issue communicating with the AI server (OpenAI).");
+                eprintln!("Reason: {}\n", e);
+                return;
             }
         };
     }

--- a/templates/src/ollama_api_client.rs
+++ b/templates/src/ollama_api_client.rs
@@ -10,6 +10,7 @@ struct Request {
     prompt: String,
     format: serde_json::Value,
     stream: bool,
+    think: bool,
     options: Options,
 }
 
@@ -25,6 +26,7 @@ struct Response {
     created_at: String,
     response: String,
     done: bool,
+    thinking: Option<String>,
 }
 
 pub async fn send_request(
@@ -40,6 +42,7 @@ pub async fn send_request(
         prompt: prompt.clone(),
         format: format.clone(),
         stream: false,
+        think: false,
         options: Options { temperature: crate::DEFAULT_TEMPERATURE}
     };
 
@@ -52,7 +55,7 @@ pub async fn send_request(
         .json(&request)
         .send()
         .await?;
-
+    
     let status = http_resp.status();
     let body_bytes = http_resp.bytes().await?;
 
@@ -69,7 +72,19 @@ pub async fn send_request(
         }
     };
 
-    Ok(reply.response)
+    // NOTE: Some Ollama "thinking" models may incorrectly place final output in the `thinking` field
+    // instead of the `response` field, even when `think` is set to false. This appears to be an
+    // Ollama-side issue. The logic below first checks `response`, and if empty, falls back to
+    // `thinking` to support current behavior.
+    let final_output = if !reply.response.is_empty() {
+        reply.response
+    } else if let Some(t) = reply.thinking {
+        t
+    } else {
+        return Err("Ollama returned neither response nor thinking fields.".into());
+    };
+
+    Ok(final_output)
 }
 
 #[cfg(test)]

--- a/weather_agent.json
+++ b/weather_agent.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.9",
+  "version": "0.0.10",
   "prompt": "Using the provided resources, determine if it will rain tomorrow between 9am and 5pm local time. Follow these exact steps: 1) Read the current local date and time from the time resource. 2) Determine the date for tomorrow. 3) From the weather data, examine precipitation probabilities for that specific date between 9:00 and 17:00 local time. 4) If any hourly probability exceeds 40%, answer true; otherwise, answer false.",
   "agent_schema": {
     "type": "object",


### PR DESCRIPTION
Implements improved handling for Ollama thinking-model output (response vs thinking fields) and enhances error reporting when contacting AI servers.

Related: #46