### PR TITLE
feat(account-mail): add prefs command and mail_preferences API client

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,19 +1,7 @@
 // clap - Command Line Arguement Parsing
 use clap::{Arg, ArgGroup, ArgMatches, Command};
 
-pub fn build_cli() -> ArgMatches {
-    // Collect the original command-line arguments
-    let mut args: Vec<String> = std::env::args().collect();
-
-    let mut bin_name = "cargo-ai";
-    // Check if runing as a cargo subcommand, i.e. cargo ai
-    if let Some(first_arg) = args.get(1) {
-        if first_arg == "ai" {
-            bin_name = "cargo ai";
-            args.remove(1);
-        }
-    }
-
+fn cli_command(bin_name: &'static str) -> Command {
     Command::new("cargo-ai")
         .bin_name(bin_name)
         .version(env!("CARGO_PKG_VERSION"))
@@ -235,6 +223,26 @@ pub fn build_cli() -> ArgMatches {
                                         .required(false)
                                         .value_name("TEXT")
                                         .num_args(1)
+                                )
+                        )
+                        .subcommand(
+                            Command::new("prefs")
+                                .about("View or set account email delivery preferences")
+                                .arg(
+                                    Arg::new("disable_all")
+                                        .long("disable-all")
+                                        .help("Disable all account emails")
+                                        .required(false)
+                                        .action(clap::ArgAction::SetTrue)
+                                        .conflicts_with("enable_all")
+                                )
+                                .arg(
+                                    Arg::new("enable_all")
+                                        .long("enable-all")
+                                        .help("Enable all account emails")
+                                        .required(false)
+                                        .action(clap::ArgAction::SetTrue)
+                                        .conflicts_with("disable_all")
                                 )
                         )
                 )
@@ -554,5 +562,90 @@ pub fn build_cli() -> ArgMatches {
                         )
                 )
         )
-        .get_matches_from(args)
+}
+
+pub fn build_cli() -> ArgMatches {
+    // Collect the original command-line arguments
+    let mut args: Vec<String> = std::env::args().collect();
+
+    let mut bin_name = "cargo-ai";
+    // Check if runing as a cargo subcommand, i.e. cargo ai
+    if let Some(first_arg) = args.get(1) {
+        if first_arg == "ai" {
+            bin_name = "cargo ai";
+            args.remove(1);
+        }
+    }
+
+    cli_command(bin_name).get_matches_from(args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cli_command;
+    use clap::error::ErrorKind;
+
+    #[test]
+    fn account_mail_prefs_defaults_to_get_intent() {
+        let matches = cli_command("cargo-ai")
+            .try_get_matches_from(["cargo-ai", "account", "mail", "prefs"])
+            .expect("prefs command should parse");
+
+        let prefs_matches = matches
+            .subcommand_matches("account")
+            .and_then(|m| m.subcommand_matches("mail"))
+            .and_then(|m| m.subcommand_matches("prefs"))
+            .expect("prefs subcommand should be available");
+
+        assert!(!prefs_matches.get_flag("disable_all"));
+        assert!(!prefs_matches.get_flag("enable_all"));
+    }
+
+    #[test]
+    fn account_mail_prefs_disable_parses() {
+        let matches = cli_command("cargo-ai")
+            .try_get_matches_from(["cargo-ai", "account", "mail", "prefs", "--disable-all"])
+            .expect("disable-all form should parse");
+
+        let prefs_matches = matches
+            .subcommand_matches("account")
+            .and_then(|m| m.subcommand_matches("mail"))
+            .and_then(|m| m.subcommand_matches("prefs"))
+            .expect("prefs subcommand should be available");
+
+        assert!(prefs_matches.get_flag("disable_all"));
+        assert!(!prefs_matches.get_flag("enable_all"));
+    }
+
+    #[test]
+    fn account_mail_prefs_enable_parses() {
+        let matches = cli_command("cargo-ai")
+            .try_get_matches_from(["cargo-ai", "account", "mail", "prefs", "--enable-all"])
+            .expect("enable-all form should parse");
+
+        let prefs_matches = matches
+            .subcommand_matches("account")
+            .and_then(|m| m.subcommand_matches("mail"))
+            .and_then(|m| m.subcommand_matches("prefs"))
+            .expect("prefs subcommand should be available");
+
+        assert!(prefs_matches.get_flag("enable_all"));
+        assert!(!prefs_matches.get_flag("disable_all"));
+    }
+
+    #[test]
+    fn account_mail_prefs_conflicting_flags_are_rejected() {
+        let err = cli_command("cargo-ai")
+            .try_get_matches_from([
+                "cargo-ai",
+                "account",
+                "mail",
+                "prefs",
+                "--disable-all",
+                "--enable-all",
+            ])
+            .expect_err("conflicting flags should fail parsing");
+
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
 }

--- a/src/infra_api/account.rs
+++ b/src/infra_api/account.rs
@@ -9,3 +9,4 @@ pub mod status;
 pub mod handle;
 pub mod agents;
 pub mod send_mail;
+pub mod mail_preferences;

--- a/src/infra_api/account/mail_preferences.rs
+++ b/src/infra_api/account/mail_preferences.rs
@@ -1,0 +1,146 @@
+use serde_json::{json, Value};
+
+fn build_fetch_preferences_body(access_token: &str) -> Value {
+    json!({
+        "action": "mail_preferences",
+        "credentials": {
+            "access_token": access_token
+        }
+    })
+}
+
+fn build_set_preferences_body(access_token: &str, all_emails_enabled: bool) -> Value {
+    json!({
+        "action": "mail_preferences",
+        "credentials": {
+            "access_token": access_token
+        },
+        "mail_preferences": {
+            "set": {
+                "all_emails_enabled": all_emails_enabled
+            }
+        }
+    })
+}
+
+/// Fetch current account mail preferences using an access token.
+///
+/// POST /account
+/// {
+///   "action": "mail_preferences",
+///   "credentials": {
+///     "access_token": "<access_token>"
+///   }
+/// }
+///
+/// Returns the raw JSON response from the infra API (success or failure).
+pub async fn fetch_preferences(base_url: &str, access_token: &str) -> Result<Value, reqwest::Error> {
+    let url = format!("{}/account", base_url.trim_end_matches('/'));
+    let body = build_fetch_preferences_body(access_token);
+
+    let client = reqwest::Client::new();
+    let resp = client.post(url).json(&body).send().await?;
+
+    // Always attempt to return the JSON body even for non-2xx responses,
+    // so the CLI can surface infra error details directly.
+    match resp.json::<Value>().await {
+        Ok(v) => Ok(v),
+        Err(e) => Err(e),
+    }
+}
+
+/// Set account-level mail preference using an access token.
+///
+/// POST /account
+/// {
+///   "action": "mail_preferences",
+///   "credentials": {
+///     "access_token": "<access_token>"
+///   },
+///   "mail_preferences": {
+///     "set": {
+///       "all_emails_enabled": <bool>
+///     }
+///   }
+/// }
+///
+/// Returns the raw JSON response from the infra API (success or failure).
+pub async fn set_all_emails_enabled(
+    base_url: &str,
+    access_token: &str,
+    all_emails_enabled: bool,
+) -> Result<Value, reqwest::Error> {
+    let url = format!("{}/account", base_url.trim_end_matches('/'));
+    let body = build_set_preferences_body(access_token, all_emails_enabled);
+
+    let client = reqwest::Client::new();
+    let resp = client.post(url).json(&body).send().await?;
+
+    // Always attempt to return the JSON body even for non-2xx responses,
+    // so the CLI can surface infra error details directly.
+    match resp.json::<Value>().await {
+        Ok(v) => Ok(v),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_fetch_preferences_body, build_set_preferences_body};
+    use serde_json::json;
+
+    #[test]
+    fn build_fetch_preferences_body_matches_contract() {
+        let body = build_fetch_preferences_body("access-token-123");
+
+        assert_eq!(
+            body,
+            json!({
+                "action": "mail_preferences",
+                "credentials": {
+                    "access_token": "access-token-123"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn build_set_preferences_body_matches_contract_for_disable() {
+        let body = build_set_preferences_body("access-token-123", false);
+
+        assert_eq!(
+            body,
+            json!({
+                "action": "mail_preferences",
+                "credentials": {
+                    "access_token": "access-token-123"
+                },
+                "mail_preferences": {
+                    "set": {
+                        "all_emails_enabled": false
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn build_set_preferences_body_matches_contract_for_enable() {
+        let body = build_set_preferences_body("access-token-123", true);
+
+        assert_eq!(
+            body,
+            json!({
+                "action": "mail_preferences",
+                "credentials": {
+                    "access_token": "access-token-123"
+                },
+                "mail_preferences": {
+                    "set": {
+                        "all_emails_enabled": true
+                    }
+                }
+            })
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -774,8 +774,190 @@ async fn main() {
                         Err(_) => println!("{response:?}"),
                     }
                 }
+            } else if let Some(prefs_m) = mail_m.subcommand_matches("prefs") {
+                let set_all_emails_enabled = if prefs_m.get_flag("disable_all") {
+                    Some(false)
+                } else if prefs_m.get_flag("enable_all") {
+                    Some(true)
+                } else {
+                    None
+                };
+
+                // 1. Load config
+                let cfg = match load_config() {
+                    Some(cfg) => cfg,
+                    None => {
+                        eprintln!(
+                            "❌ No local config file found at '{}'. Run `cargo ai account register <email>` on this machine, or copy your config from another machine.",
+                            config_path().display()
+                        );
+                        return;
+                    }
+                };
+
+                // 2. Extract account
+                let acct = match cfg.account.as_ref() {
+                    Some(acct) => acct,
+                    None => {
+                        eprintln!("❌ No account found in config. You must confirm your account first.");
+                        return;
+                    }
+                };
+
+                // 3. Extract access token
+                let access_token = match acct.access_token.as_ref() {
+                    Some(t) => t,
+                    None => {
+                        eprintln!("❌ No access token found in config. Run `cargo ai account confirm <code>` first.");
+                        return;
+                    }
+                };
+                let refresh_token = acct.refresh_token.as_ref();
+
+                // 4. Route GET vs SET (first attempt with current access token)
+                let access_token_owned = access_token.clone();
+                let mut response = if let Some(all_emails_enabled) = set_all_emails_enabled {
+                    match infra_api::account::mail_preferences::set_all_emails_enabled(
+                        INFRA_BASE_URL,
+                        access_token_owned.as_str(),
+                        all_emails_enabled,
+                    )
+                    .await
+                    {
+                        Ok(r) => r,
+                        Err(e) => {
+                            eprintln!("❌ Request failed: {e:?}");
+                            return;
+                        }
+                    }
+                } else {
+                    match infra_api::account::mail_preferences::fetch_preferences(
+                        INFRA_BASE_URL,
+                        access_token_owned.as_str(),
+                    )
+                    .await
+                    {
+                        Ok(r) => r,
+                        Err(e) => {
+                            eprintln!("❌ Request failed: {e:?}");
+                            return;
+                        }
+                    }
+                };
+
+                // 5. If access token is expired, refresh via status and retry once.
+                let is_expired_error = response
+                    .get("type")
+                    .and_then(|v| v.as_str())
+                    .map(|t| t == "access_token_expired")
+                    .unwrap_or(false);
+
+                if is_expired_error {
+                    let rt = match refresh_token {
+                        Some(rt) => rt,
+                        None => {
+                            eprintln!("⚠️ Access token expired, and no refresh token exists in config. Run `cargo ai account status` or re-confirm account.");
+                            if !ui::account_status::render_backend_ui(&response) {
+                                match serde_json::to_string_pretty(&response) {
+                                    Ok(pretty) => println!("{pretty}"),
+                                    Err(_) => println!("{response:?}"),
+                                }
+                            }
+                            return;
+                        }
+                    };
+
+                    let refresh_response = match infra_api::account::status::fetch_status(
+                        INFRA_BASE_URL,
+                        access_token_owned.as_str(),
+                        Some(rt.as_str()),
+                    )
+                    .await
+                    {
+                        Ok(r) => r,
+                        Err(e) => {
+                            eprintln!("❌ Request failed while refreshing session: {e:?}");
+                            return;
+                        }
+                    };
+
+                    let refreshed_access_token = refresh_response
+                        .get("session")
+                        .and_then(|s| s.get("access_token"))
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.to_string());
+
+                    let refreshed_expires_in: Option<i32> = refresh_response
+                        .get("session")
+                        .and_then(|s| s.get("expires_in_seconds"))
+                        .and_then(|v| v.as_i64())
+                        .and_then(|n| i32::try_from(n).ok());
+
+                    let retry_access_token = match refreshed_access_token {
+                        Some(ref at) => {
+                            if let Some(expires_in) = refreshed_expires_in {
+                                if let Err(e) =
+                                    set_account_tokens(at.to_string(), rt.clone(), expires_in)
+                                {
+                                    eprintln!("⚠️ Failed to update account tokens in config: {e}");
+                                }
+                            }
+                            at.clone()
+                        }
+                        None => {
+                            eprintln!("⚠️ Session refresh did not return a new access token. Cannot retry mail-preferences request.");
+                            if !ui::account_status::render_backend_ui(&refresh_response) {
+                                match serde_json::to_string_pretty(&refresh_response) {
+                                    Ok(pretty) => println!("{pretty}"),
+                                    Err(_) => println!("{refresh_response:?}"),
+                                }
+                            }
+                            return;
+                        }
+                    };
+
+                    response = if let Some(all_emails_enabled) = set_all_emails_enabled {
+                        match infra_api::account::mail_preferences::set_all_emails_enabled(
+                            INFRA_BASE_URL,
+                            retry_access_token.as_str(),
+                            all_emails_enabled,
+                        )
+                        .await
+                        {
+                            Ok(r) => r,
+                            Err(e) => {
+                                eprintln!("❌ Request failed after session refresh: {e:?}");
+                                return;
+                            }
+                        }
+                    } else {
+                        match infra_api::account::mail_preferences::fetch_preferences(
+                            INFRA_BASE_URL,
+                            retry_access_token.as_str(),
+                        )
+                        .await
+                        {
+                            Ok(r) => r,
+                            Err(e) => {
+                                eprintln!("❌ Request failed after session refresh: {e:?}");
+                                return;
+                            }
+                        }
+                    };
+                }
+
+                // 6. Render backend-provided UI when available, fallback to raw JSON.
+                if !ui::account_status::render_backend_ui(&response) {
+                    match serde_json::to_string_pretty(&response) {
+                        Ok(pretty) => println!("{pretty}"),
+                        Err(_) => println!("{response:?}"),
+                    }
+                }
             } else {
-                println!("No mail subcommand found. Try 'cargo ai account mail test'.");
+                println!(
+                    "No mail subcommand found. Try 'cargo ai account mail test' or 'cargo ai account mail prefs [--disable-all|--enable-all]'."
+                );
             }
         } else if let Some(handle_m) = sub_m.subcommand_matches("handle") {
             // Account handle: get current handle or set a new one.
@@ -1699,7 +1881,7 @@ async fn main() {
                 );
             }
         } else {
-            println!("No account subcommand found. Try 'cargo ai account register <email>', 'cargo ai account confirm <code>', 'cargo ai account status', 'cargo ai account mail test [--subject <text>] [--text <text>]', 'cargo ai account handle [--set <handle>]', or 'cargo ai account agents <list|push|pull|hatch|visibility|archive>'.");
+            println!("No account subcommand found. Try 'cargo ai account register <email>', 'cargo ai account confirm <code>', 'cargo ai account status', 'cargo ai account mail test [--subject <text>] [--text <text>]', 'cargo ai account mail prefs [--disable-all|--enable-all]', 'cargo ai account handle [--set <handle>]', or 'cargo ai account agents <list|push|pull|hatch|visibility|archive>'.");
         }
 
     } else if let Some(sub_m) = cmd_args.subcommand_matches("profile") {


### PR DESCRIPTION
- add `cargo ai account mail prefs` with `--disable-all`/`--enable-all` mutual exclusion in CLI args
- implement mail preference GET/SET dispatch in account mail flow with access-token refresh/retry parity
- add infra API mail_preferences module for request payloads and account endpoint calls
- add parser and payload contract tests for 1B behavior

Related to: CAI-240