### PR TITLE
fix(ci): use runtime text input override in multi-os workflow

### DIFF
--- a/.github/workflows/multi-os-ci.yml
+++ b/.github/workflows/multi-os-ci.yml
@@ -62,12 +62,12 @@ jobs:
           }
         shell: bash
 
-      - name: Validate agent_adder output with overridden prompt
+      - name: Validate agent_adder output with overridden text input
         run: |
           if [[ "$RUNNER_OS" == "Windows" ]]; then
-            OUTPUT=$(./adder_test.exe -s openai -m gpt-4o --token ${{ secrets.OPENAI_API_KEY }} --prompt "2+3")
+            OUTPUT=$(./adder_test.exe -s openai -m gpt-4o --token ${{ secrets.OPENAI_API_KEY }} --input-text "What is 2 + 3? Return the answer as a number.")
           else
-            OUTPUT=$(./adder_test -s openai -m gpt-4o --token ${{ secrets.OPENAI_API_KEY }} --prompt "2+3")
+            OUTPUT=$(./adder_test -s openai -m gpt-4o --token ${{ secrets.OPENAI_API_KEY }} --input-text "What is 2 + 3? Return the answer as a number.")
           fi
 
           echo "$OUTPUT"


### PR DESCRIPTION
- replace the removed --prompt flag with --input-text in the adder_test override check
- keep Windows and non-Windows override semantics aligned
- rename the workflow step to reflect overridden text input behavior

Related to: CAI-2038