### PR TITLE
feat(web): harden URL input fetch compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ cargo ai hatch weather_test --config weather_test.json
   ```
 
   You can use multiple `text` inputs, multiple `url` inputs, and later local `image` inputs. Runtime flags such as `--input-text`, `--input-url`, and `--input-image` replace the config-defined inputs when present.
+  For `type: "url"`, Cargo AI fetches the content with its own HTTP client before sending the text to the model. Treat the target compatibility bar as comparable to `curl` for ordinary static or server-rendered pages, not as a guarantee for browser-only or JavaScript-rendered content.
 
 ### 2) Define the Response Schema
 

--- a/src/web_resources.rs
+++ b/src/web_resources.rs
@@ -1,13 +1,16 @@
 use crate::config::loader::load_config;
 use crate::config::schema::WebResources as WebResourcesConfig;
 use futures::future::join_all;
-use reqwest::StatusCode;
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, USER_AGENT};
+use reqwest::{Client, StatusCode};
 use tokio::time::{sleep, Duration};
 
 const DEFAULT_MAX_ATTEMPTS: u32 = 3;
 const MAX_MAX_ATTEMPTS: u32 = 5;
 const DEFAULT_BASE_BACKOFF_MS: u64 = 500;
 const MAX_BASE_BACKOFF_MS: u64 = 5_000;
+const WEB_RESOURCE_ACCEPT_HEADER: &str =
+    "text/html,application/xhtml+xml,application/xml;q=0.9,text/plain;q=0.8,*/*;q=0.5";
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 struct RetryPolicy {
@@ -58,6 +61,26 @@ fn should_retry_status(status: StatusCode) -> bool {
         || status.is_server_error()
 }
 
+fn web_resource_user_agent() -> String {
+    format!(
+        "cargo-ai/{} (+https://cargo-ai.org)",
+        env!("CARGO_PKG_VERSION")
+    )
+}
+
+fn build_web_resource_client() -> Result<Client, String> {
+    let mut headers = HeaderMap::new();
+    let user_agent = HeaderValue::from_str(&web_resource_user_agent())
+        .map_err(|error| format!("Failed to build web-resource User-Agent header: {error}"))?;
+    headers.insert(USER_AGENT, user_agent);
+    headers.insert(ACCEPT, HeaderValue::from_static(WEB_RESOURCE_ACCEPT_HEADER));
+
+    Client::builder()
+        .default_headers(headers)
+        .build()
+        .map_err(|error| format!("Failed to build web-resource HTTP client: {error}"))
+}
+
 fn truncate_error_body(body: &str) -> String {
     let normalized = body.replace('\n', " ").replace('\r', " ");
     let trimmed = normalized.trim();
@@ -74,8 +97,43 @@ async fn maybe_backoff(attempt: u32, policy: RetryPolicy) {
     sleep(Duration::from_millis(delay)).await;
 }
 
+fn request_shape_hint(status: StatusCode) -> Option<&'static str> {
+    match status {
+        StatusCode::FORBIDDEN | StatusCode::NOT_ACCEPTABLE | StatusCode::UNSUPPORTED_MEDIA_TYPE => {
+            Some(
+                " The server rejected Cargo AI's HTTP request shape. If the URL works in curl or a browser, the endpoint may expect different request headers or browser-only behavior.",
+            )
+        }
+        _ => None,
+    }
+}
+
+fn format_http_error(status: StatusCode, url: &str, body: &str, retryable: bool) -> String {
+    let mut message = if retryable {
+        format!(
+            "Retryable HTTP error {} for '{}': {}",
+            status,
+            url,
+            truncate_error_body(body)
+        )
+    } else {
+        format!(
+            "HTTP error {} for '{}': {}",
+            status,
+            url,
+            truncate_error_body(body)
+        )
+    };
+
+    if let Some(hint) = request_shape_hint(status) {
+        message.push_str(hint);
+    }
+
+    message
+}
+
 async fn fetch_resource_with_policy(
-    client: &reqwest::Client,
+    client: &Client,
     url: &str,
     policy: RetryPolicy,
 ) -> Result<String, String> {
@@ -117,20 +175,13 @@ async fn fetch_resource_with_policy(
 
             if should_retry_status(status) {
                 return Err(format!(
-                    "Retryable HTTP error {} for '{}' after {} attempts: {}",
-                    status,
-                    url,
-                    policy.max_attempts,
-                    truncate_error_body(&body)
+                    "{} after {} attempts.",
+                    format_http_error(status, url, &body, true),
+                    policy.max_attempts
                 ));
             }
 
-            return Err(format!(
-                "HTTP error {} for '{}': {}",
-                status,
-                url,
-                truncate_error_body(&body)
-            ));
+            return Err(format_http_error(status, url, &body, false));
         }
 
         if policy.retry_on_empty_body && body.trim().is_empty() {
@@ -155,7 +206,7 @@ async fn fetch_resources_parallel_with_policy(
     urls: &[&str],
     policy: RetryPolicy,
 ) -> Result<Vec<String>, String> {
-    let client = reqwest::Client::new();
+    let client = build_web_resource_client()?;
     let futures = urls
         .iter()
         .map(|url| fetch_resource_with_policy(&client, url, policy));
@@ -193,19 +244,38 @@ mod tests {
         )
     }
 
-    async fn spawn_sequence_server(responses: Vec<String>) -> (String, JoinHandle<()>) {
+    async fn read_http_request(socket: &mut tokio::net::TcpStream) -> String {
+        let mut request = Vec::new();
+        let mut buffer = [0_u8; 1024];
+
+        loop {
+            let bytes_read = socket.read(&mut buffer).await.expect("read request");
+            if bytes_read == 0 {
+                break;
+            }
+            request.extend_from_slice(&buffer[..bytes_read]);
+            if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        String::from_utf8(request).expect("request should be utf8")
+    }
+
+    async fn spawn_sequence_server(responses: Vec<String>) -> (String, JoinHandle<Vec<String>>) {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind test server");
         let addr = listener.local_addr().expect("local addr");
 
         let handle = tokio::spawn(async move {
+            let mut requests = Vec::new();
             for response in responses {
                 let (mut socket, _) = listener.accept().await.expect("accept connection");
-                let mut buffer = [0_u8; 1024];
-                let _ = socket.read(&mut buffer).await;
+                requests.push(read_http_request(&mut socket).await);
                 let _ = socket.write_all(response.as_bytes()).await;
             }
+            requests
         });
 
         (format!("http://{}/resource", addr), handle)
@@ -253,6 +323,43 @@ mod tests {
             .expect_err("resource fetch should fail");
 
         assert!(error.contains("HTTP error 401"));
+        server_task.await.expect("server task");
+    }
+
+    #[tokio::test]
+    async fn sends_cargo_ai_web_fetch_headers() {
+        let (url, server_task) =
+            spawn_sequence_server(vec![http_response("200 OK", "payload")]).await;
+
+        let result = fetch_resources_parallel_with_policy(&[url.as_str()], policy(1, 1, true))
+            .await
+            .expect("resource fetch should succeed");
+
+        assert_eq!(result, vec!["payload"]);
+
+        let requests = server_task.await.expect("server task");
+        let request = requests.first().expect("captured request");
+        let request_lower = request.to_ascii_lowercase();
+
+        assert!(request_lower.contains("user-agent: cargo-ai/"));
+        assert!(request_lower.contains(
+            "accept: text/html,application/xhtml+xml,application/xml;q=0.9,text/plain;q=0.8,*/*;q=0.5"
+        ));
+    }
+
+    #[tokio::test]
+    async fn adds_request_shape_hint_for_header_sensitive_statuses() {
+        let (url, server_task) =
+            spawn_sequence_server(vec![http_response("403 Forbidden", "blocked")]).await;
+
+        let error = fetch_resources_parallel_with_policy(&[url.as_str()], policy(1, 1, true))
+            .await
+            .expect_err("resource fetch should fail");
+
+        assert!(error.contains("HTTP error 403"));
+        assert!(error.contains("request shape"));
+        assert!(error.contains("curl or a browser"));
+
         server_task.await.expect("server task");
     }
 }

--- a/templates/guidance/agent-definition-contract.md
+++ b/templates/guidance/agent-definition-contract.md
@@ -39,6 +39,11 @@ Path rules for `image` and `file`:
 - Do not use absolute paths.
 - Do not use parent traversal such as `../`.
 
+URL guidance:
+- `{"type":"url","url":"..."}` means Cargo AI fetches the URL with its own HTTP client and passes the returned body as text input.
+- Treat the practical compatibility target as comparable to `curl` for ordinary static or server-rendered content.
+- Do not assume browser-only or JavaScript-rendered pages will work through `type: "url"`.
+
 ## Runtime Inputs
 
 Generated agent binaries may also accept runtime input flags such as:

--- a/templates/guidance/codex-agents.md.tmpl
+++ b/templates/guidance/codex-agents.md.tmpl
@@ -61,6 +61,7 @@ Useful examples:
   - `minimum`, `maximum`, `exclusiveMinimum`, and `exclusiveMaximum` on `number` and `integer`
 - Treat top-level arrays, nested objects, and union types as unsupported unless the local contract docs say otherwise.
 - Treat the local contract and action helper docs as authoritative for step fields such as `platform`, runtime input override behavior, and child-agent data-flow limits.
+- For `type: "url"`, prefer content Cargo AI can fetch directly with a normal HTTP request; treat `curl`-comparable ordinary pages as the target floor, not browser-only or JavaScript-rendered pages.
 - Prefer the most minimal portable steps that satisfy the user's goal.
 - Use platform-specific commands only when the user explicitly wants local-machine behavior or the task cannot be met portably.
 - Remember that runtime input flags replace the full baked `inputs` array for that run.

--- a/templates/src/web_resources.rs
+++ b/templates/src/web_resources.rs
@@ -1,13 +1,16 @@
 use crate::config::loader::load_config;
 use crate::config::schema::WebResources as WebResourcesConfig;
 use futures::future::join_all;
-use reqwest::StatusCode;
+use reqwest::header::{ACCEPT, HeaderMap, HeaderValue, USER_AGENT};
+use reqwest::{Client, StatusCode};
 use tokio::time::{Duration, sleep};
 
 const DEFAULT_MAX_ATTEMPTS: u32 = 3;
 const MAX_MAX_ATTEMPTS: u32 = 5;
 const DEFAULT_BASE_BACKOFF_MS: u64 = 500;
 const MAX_BASE_BACKOFF_MS: u64 = 5_000;
+const WEB_RESOURCE_ACCEPT_HEADER: &str =
+    "text/html,application/xhtml+xml,application/xml;q=0.9,text/plain;q=0.8,*/*;q=0.5";
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 struct RetryPolicy {
@@ -58,6 +61,26 @@ fn should_retry_status(status: StatusCode) -> bool {
         || status.is_server_error()
 }
 
+fn web_resource_user_agent() -> String {
+    format!(
+        "cargo-ai/{} (+https://cargo-ai.org)",
+        env!("CARGO_PKG_VERSION")
+    )
+}
+
+fn build_web_resource_client() -> Result<Client, String> {
+    let mut headers = HeaderMap::new();
+    let user_agent = HeaderValue::from_str(&web_resource_user_agent())
+        .map_err(|error| format!("Failed to build web-resource User-Agent header: {error}"))?;
+    headers.insert(USER_AGENT, user_agent);
+    headers.insert(ACCEPT, HeaderValue::from_static(WEB_RESOURCE_ACCEPT_HEADER));
+
+    Client::builder()
+        .default_headers(headers)
+        .build()
+        .map_err(|error| format!("Failed to build web-resource HTTP client: {error}"))
+}
+
 fn truncate_error_body(body: &str) -> String {
     let normalized = body.replace('\n', " ").replace('\r', " ");
     let trimmed = normalized.trim();
@@ -74,8 +97,38 @@ async fn maybe_backoff(attempt: u32, policy: RetryPolicy) {
     sleep(Duration::from_millis(delay)).await;
 }
 
+fn request_shape_hint(status: StatusCode) -> Option<&'static str> {
+    match status {
+        StatusCode::FORBIDDEN | StatusCode::NOT_ACCEPTABLE | StatusCode::UNSUPPORTED_MEDIA_TYPE => {
+            Some(
+                " The server rejected Cargo AI's HTTP request shape. If the URL works in curl or a browser, the endpoint may expect different request headers or browser-only behavior.",
+            )
+        }
+        _ => None,
+    }
+}
+
+fn format_http_error(status: StatusCode, url: &str, body: &str, retryable: bool) -> String {
+    let mut message = if retryable {
+        format!(
+            "Retryable HTTP error {} for '{}': {}",
+            status,
+            url,
+            truncate_error_body(body)
+        )
+    } else {
+        format!("HTTP error {} for '{}': {}", status, url, truncate_error_body(body))
+    };
+
+    if let Some(hint) = request_shape_hint(status) {
+        message.push_str(hint);
+    }
+
+    message
+}
+
 async fn fetch_resource_with_policy(
-    client: &reqwest::Client,
+    client: &Client,
     url: &str,
     policy: RetryPolicy,
 ) -> Result<String, String> {
@@ -117,20 +170,13 @@ async fn fetch_resource_with_policy(
 
             if should_retry_status(status) {
                 return Err(format!(
-                    "Retryable HTTP error {} for '{}' after {} attempts: {}",
-                    status,
-                    url,
-                    policy.max_attempts,
-                    truncate_error_body(&body)
+                    "{} after {} attempts.",
+                    format_http_error(status, url, &body, true),
+                    policy.max_attempts
                 ));
             }
 
-            return Err(format!(
-                "HTTP error {} for '{}': {}",
-                status,
-                url,
-                truncate_error_body(&body)
-            ));
+            return Err(format_http_error(status, url, &body, false));
         }
 
         if policy.retry_on_empty_body && body.trim().is_empty() {
@@ -155,7 +201,7 @@ async fn fetch_resources_parallel_with_policy(
     urls: &[&str],
     policy: RetryPolicy,
 ) -> Result<Vec<String>, String> {
-    let client = reqwest::Client::new();
+    let client = build_web_resource_client()?;
     let futures = urls
         .iter()
         .map(|url| fetch_resource_with_policy(&client, url, policy));
@@ -193,19 +239,38 @@ mod tests {
         )
     }
 
-    async fn spawn_sequence_server(responses: Vec<String>) -> (String, JoinHandle<()>) {
+    async fn read_http_request(socket: &mut tokio::net::TcpStream) -> String {
+        let mut request = Vec::new();
+        let mut buffer = [0_u8; 1024];
+
+        loop {
+            let bytes_read = socket.read(&mut buffer).await.expect("read request");
+            if bytes_read == 0 {
+                break;
+            }
+            request.extend_from_slice(&buffer[..bytes_read]);
+            if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        String::from_utf8(request).expect("request should be utf8")
+    }
+
+    async fn spawn_sequence_server(responses: Vec<String>) -> (String, JoinHandle<Vec<String>>) {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind test server");
         let addr = listener.local_addr().expect("local addr");
 
         let handle = tokio::spawn(async move {
+            let mut requests = Vec::new();
             for response in responses {
                 let (mut socket, _) = listener.accept().await.expect("accept connection");
-                let mut buffer = [0_u8; 1024];
-                let _ = socket.read(&mut buffer).await;
+                requests.push(read_http_request(&mut socket).await);
                 let _ = socket.write_all(response.as_bytes()).await;
             }
+            requests
         });
 
         (format!("http://{}/resource", addr), handle)
@@ -253,6 +318,43 @@ mod tests {
             .expect_err("resource fetch should fail");
 
         assert!(error.contains("HTTP error 401"));
+        server_task.await.expect("server task");
+    }
+
+    #[tokio::test]
+    async fn sends_cargo_ai_web_fetch_headers() {
+        let (url, server_task) =
+            spawn_sequence_server(vec![http_response("200 OK", "payload")]).await;
+
+        let result = fetch_resources_parallel_with_policy(&[url.as_str()], policy(1, 1, true))
+            .await
+            .expect("resource fetch should succeed");
+
+        assert_eq!(result, vec!["payload"]);
+
+        let requests = server_task.await.expect("server task");
+        let request = requests.first().expect("captured request");
+        let request_lower = request.to_ascii_lowercase();
+
+        assert!(request_lower.contains("user-agent: cargo-ai/"));
+        assert!(request_lower.contains(
+            "accept: text/html,application/xhtml+xml,application/xml;q=0.9,text/plain;q=0.8,*/*;q=0.5"
+        ));
+    }
+
+    #[tokio::test]
+    async fn adds_request_shape_hint_for_header_sensitive_statuses() {
+        let (url, server_task) =
+            spawn_sequence_server(vec![http_response("403 Forbidden", "blocked")]).await;
+
+        let error = fetch_resources_parallel_with_policy(&[url.as_str()], policy(1, 1, true))
+            .await
+            .expect_err("resource fetch should fail");
+
+        assert!(error.contains("HTTP error 403"));
+        assert!(error.contains("request shape"));
+        assert!(error.contains("curl or a browser"));
+
         server_task.await.expect("server task");
     }
 }


### PR DESCRIPTION
- add Cargo AI default headers to web resource fetches and mirror them in generated runtimes
- add request-shape hints for header-sensitive HTTP failures and cover header behavior with focused tests
- document curl-comparable URL input expectations in README and Codex guidance templates

Related to: CAI-2042