### PR TITLE
feat(actions): add generate_image run step

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ Then expand into multiple action types:
 
 </details>
 
-You can keep actions simple or mix local executables, email alerts, and child-agent handoffs in the same agent definition. The next section shows how to sequence multiple run steps and control them with `when`.
+You can keep actions simple or mix local executables, email alerts, child-agent handoffs, and generated image artifacts in the same agent definition. The next section shows how to sequence multiple run steps and control them with `when`.
 
 ### `run`
 
@@ -571,7 +571,18 @@ Then expand into a multi-step workflow:
 
 </details>
 
-Use `run` to sequence multiple side effects in order. `exec` steps can capture output, status, or errors for later steps, and `when` lets later steps react to success or failure without leaving the agent definition.
+Use `run` to sequence multiple side effects in order. `exec` steps can capture output, status, or errors for later steps, `generate_image` can write a single local image artifact, and `when` lets later steps react to success or failure without leaving the agent definition.
+
+First-slice image generation uses an explicit model and a local output path. For the default OpenAI account transport, use a tool-capable mainline model such as `gpt-5.2`. For a direct OpenAI API token and URL, use an image model such as `gpt-image-1`.
+
+```json
+{
+  "kind": "generate_image",
+  "model": "gpt-5.2",
+  "prompt": ["Create a product render for ", { "var": "reason" }],
+  "path": "./artifacts/product_render.png"
+}
+```
 
 You can also target individual run steps to specific runtime platforms:
 

--- a/src/commands/preflight.rs
+++ b/src/commands/preflight.rs
@@ -599,10 +599,17 @@ pub async fn run(sub_m: &ArgMatches) -> bool {
     // Get Actions
     let actions = crate::actions();
     // println!("Actions {:?}", actions);
+    let action_provider_context = super::preflight_actions::ActionProviderContext {
+        provider,
+        url: url.clone(),
+        token: token.clone(),
+        inference_timeout_in_sec,
+    };
 
     match super::preflight_actions::apply_actions(
         &output,
         &actions,
+        &action_provider_context,
         max_agent_depth,
         runtime_budget,
     )

--- a/src/commands/preflight_actions.rs
+++ b/src/commands/preflight_actions.rs
@@ -24,6 +24,14 @@ pub(crate) struct InvocationRuntimeBudget {
     pub(crate) deadline_ms: u64,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct ActionProviderContext {
+    pub(crate) provider: crate::providers::ProviderKind,
+    pub(crate) url: String,
+    pub(crate) token: String,
+    pub(crate) inference_timeout_in_sec: u64,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum StepExecutionOutcome {
     Completed,
@@ -48,6 +56,7 @@ enum RefreshAccessError {
 pub(crate) async fn apply_actions(
     output: &crate::Output,
     actions: &[crate::Action],
+    provider_context: &ActionProviderContext,
     max_agent_depth: u32,
     runtime_budget: InvocationRuntimeBudget,
 ) -> Result<(), String> {
@@ -111,6 +120,16 @@ pub(crate) async fn apply_actions(
                                 &action_data,
                                 &action.name,
                                 max_agent_depth,
+                                runtime_budget,
+                            )
+                            .await
+                            .map(|outcome| (outcome, None))
+                        } else if step.kind.eq_ignore_ascii_case("generate_image") {
+                            run_generate_image_step(
+                                step,
+                                &action_data,
+                                &action.name,
+                                provider_context,
                                 runtime_budget,
                             )
                             .await
@@ -483,6 +502,128 @@ async fn run_email_me_step(
     } else {
         StepExecutionOutcome::Completed
     })
+}
+
+async fn run_generate_image_step(
+    step: &crate::RunStep,
+    data: &serde_json::Value,
+    action_name: &str,
+    provider_context: &ActionProviderContext,
+    runtime_budget: InvocationRuntimeBudget,
+) -> Result<StepExecutionOutcome, String> {
+    if provider_context.provider != crate::providers::ProviderKind::OpenAi {
+        return Err(format!(
+            "Action '{}' generate_image step requires `--server openai`; current server is {}.",
+            action_name,
+            provider_context.provider.display_name()
+        ));
+    }
+
+    let model = step.model.as_ref().ok_or_else(|| {
+        format!(
+            "Action '{}' generate_image step is missing required `model`.",
+            action_name
+        )
+    })?;
+
+    if provider_context
+        .url
+        .contains("chatgpt.com/backend-api/codex")
+        && model.starts_with("gpt-image")
+    {
+        return Err(format!(
+            "Action '{}' generate_image step uses OpenAI account transport, so `model` must be a tool-capable mainline model such as `gpt-5.2`, not '{}'.",
+            action_name, model
+        ));
+    }
+    let prompt_parts = step.prompt.as_deref().ok_or_else(|| {
+        format!(
+            "Action '{}' generate_image step is missing required `prompt`.",
+            action_name
+        )
+    })?;
+    let path_parts = step.path.as_deref().ok_or_else(|| {
+        format!(
+            "Action '{}' generate_image step is missing required `path`.",
+            action_name
+        )
+    })?;
+
+    let prompt = resolve_string_parts(prompt_parts, data, action_name, "prompt")
+        .map_err(|error| format!("Action '{}': {error}", action_name))?;
+    let output_path = resolve_string_parts(path_parts, data, action_name, "path")
+        .map_err(|error| format!("Action '{}': {error}", action_name))?;
+    let output_format = generated_image_output_format(output_path.as_str(), action_name)?;
+
+    let remaining = remaining_runtime_duration(
+        runtime_budget,
+        &format!("before starting image generation with model '{}'", model),
+    )
+    .map_err(|context| {
+        action_runtime_timeout_message(action_name, runtime_budget, context.as_str())
+    })?;
+
+    let image_bytes = match tokio::time::timeout(
+        remaining,
+        crate::providers::send_openai_image_request(
+            &provider_context.url,
+            model,
+            prompt.as_str(),
+            provider_context.inference_timeout_in_sec,
+            &provider_context.token,
+            output_format,
+        ),
+    )
+    .await
+    {
+        Ok(Ok(bytes)) => bytes,
+        Ok(Err(error)) => {
+            let mut lines = vec![format!(
+                "Action '{}' generate_image step failed.",
+                action_name
+            )];
+            lines.extend(crate::providers::provider_error_messages(&error));
+            return Err(lines.join("\n"));
+        }
+        Err(_) => {
+            return Err(action_runtime_timeout_message(
+                action_name,
+                runtime_budget,
+                "while waiting for image generation",
+            ));
+        }
+    };
+
+    let output_path_ref = Path::new(output_path.as_str());
+    validate_generated_image_output_path(output_path_ref, action_name)?;
+    if let Some(parent) = output_path_ref.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                format!(
+                    "Action '{}' failed to create image output directory '{}': {}",
+                    action_name,
+                    parent.display(),
+                    error
+                )
+            })?;
+        }
+    }
+
+    std::fs::write(output_path_ref, image_bytes).map_err(|error| {
+        format!(
+            "Action '{}' failed to write generated image '{}': {}",
+            action_name,
+            output_path_ref.display(),
+            error
+        )
+    })?;
+
+    println!(
+        "ℹ️ Action '{}' wrote generated image to '{}'.",
+        action_name,
+        output_path_ref.display()
+    );
+    Ok(StepExecutionOutcome::Completed)
 }
 
 async fn run_agent_step(
@@ -1183,6 +1324,53 @@ fn child_input_uses_dynamic_parts(parts: &[crate::RunArg]) -> bool {
         .any(|part| matches!(part, crate::RunArg::Variable(_)))
 }
 
+fn validate_generated_image_output_path(path: &Path, action_name: &str) -> Result<(), String> {
+    let raw_path = path.to_string_lossy();
+    if raw_path.trim().is_empty() {
+        return Err(format!(
+            "Action '{}' generate_image `path` must resolve to a non-empty relative path.",
+            action_name
+        ));
+    }
+    if path.is_absolute() {
+        return Err(format!(
+            "Action '{}' generate_image `path` must resolve to a relative path.",
+            action_name
+        ));
+    }
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(format!(
+            "Action '{}' generate_image `path` must not use parent traversal (`..`).",
+            action_name
+        ));
+    }
+
+    generated_image_output_format(raw_path.as_ref(), action_name).map(|_| ())
+}
+
+fn generated_image_output_format(
+    raw_path: &str,
+    action_name: &str,
+) -> Result<&'static str, String> {
+    let extension = Path::new(raw_path)
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(|value| value.to_ascii_lowercase());
+
+    match extension.as_deref() {
+        Some("png") => Ok("png"),
+        Some("jpg") | Some("jpeg") => Ok("jpeg"),
+        Some("webp") => Ok("webp"),
+        _ => Err(format!(
+            "Action '{}' generate_image `path` must use a supported extension: `.png`, `.jpg`, `.jpeg`, `.webp`.",
+            action_name
+        )),
+    }
+}
+
 fn validate_child_input_url(
     url: &str,
     action_name: &str,
@@ -1348,8 +1536,10 @@ mod tests {
         configured_agent_action_runtime_budget, format_backend_error_message,
         format_backend_ui_message, insert_action_output_variable, matching_run_steps,
         resolve_run_args, resolve_string_parts, run_agent_step, run_completion_message_for_depth,
-        run_exec_step, step_matches_platform, validate_agent_action_depth, StepExecutionOutcome,
+        run_exec_step, run_generate_image_step, step_matches_platform, validate_agent_action_depth,
+        ActionProviderContext, StepExecutionOutcome,
     };
+    use crate::providers::ProviderKind;
     use serde_json::json;
 
     fn run_step(
@@ -1360,12 +1550,15 @@ mod tests {
         crate::RunStep {
             kind: "exec".to_string(),
             program: Some(program.to_string()),
+            model: None,
             output_variable: None,
             status_variable: None,
             error_variable: None,
             failure_mode: None,
             when: None,
             args,
+            prompt: None,
+            path: None,
             subject: None,
             text: None,
             agent: None,
@@ -1377,6 +1570,15 @@ mod tests {
                     .map(|platform| platform.to_string())
                     .collect()
             }),
+        }
+    }
+
+    fn provider_context() -> ActionProviderContext {
+        ActionProviderContext {
+            provider: ProviderKind::OpenAi,
+            url: "https://api.openai.com/v1/chat/completions".to_string(),
+            token: "test-token".to_string(),
+            inference_timeout_in_sec: 60,
         }
     }
 
@@ -1690,6 +1892,7 @@ mod tests {
         let step = crate::RunStep {
             kind: "exec".to_string(),
             program: Some("/bin/sh".to_string()),
+            model: None,
             output_variable: Some("report_listing".to_string()),
             status_variable: None,
             error_variable: None,
@@ -1699,6 +1902,8 @@ mod tests {
                 crate::RunArg::Literal("-lc".to_string()),
                 crate::RunArg::Literal("printf 'alpha\\nbeta\\n'".to_string()),
             ],
+            prompt: None,
+            path: None,
             subject: None,
             text: None,
             agent: None,
@@ -1716,6 +1921,75 @@ mod tests {
             captured_output,
             Some(("report_listing".to_string(), "alpha\nbeta".to_string()))
         );
+    }
+
+    #[tokio::test]
+    async fn generate_image_step_writes_single_output_file() {
+        use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
+
+        let mut server = mockito::Server::new_async().await;
+        let expected_bytes = b"fake-png";
+        let encoded_image = BASE64_STANDARD.encode(expected_bytes);
+        let _mock = server
+            .mock("POST", "/v1/images/generations")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(
+                r#"{{"data":[{{"b64_json":"{}"}}]}}"#,
+                encoded_image
+            ))
+            .create_async()
+            .await;
+
+        let output_name = format!(".tmp-cai2054-generated-image-{}.png", std::process::id());
+        let step = crate::RunStep {
+            kind: "generate_image".to_string(),
+            program: None,
+            model: Some("gpt-image-1".to_string()),
+            output_variable: None,
+            status_variable: None,
+            error_variable: None,
+            failure_mode: None,
+            when: None,
+            args: Vec::new(),
+            prompt: Some(vec![
+                crate::RunArg::Literal("Create an image for ".to_string()),
+                crate::RunArg::Variable("customer".to_string()),
+            ]),
+            path: Some(vec![crate::RunArg::Literal(output_name.clone())]),
+            subject: None,
+            text: None,
+            agent: None,
+            inputs: None,
+            input_mode: None,
+            platforms: None,
+        };
+        let provider_context = ActionProviderContext {
+            provider: ProviderKind::OpenAi,
+            url: format!("{}/v1/chat/completions", server.url()),
+            token: "test-token".to_string(),
+            inference_timeout_in_sec: 60,
+        };
+
+        let runtime_budget = configured_agent_action_runtime_budget(Some(600));
+        let result = run_generate_image_step(
+            &step,
+            &json!({ "customer": "Acme" }),
+            "generate_art",
+            &provider_context,
+            runtime_budget,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "image generation should succeed: {result:?}"
+        );
+
+        let written_bytes =
+            std::fs::read(&output_name).expect("generated image file should be written");
+        let _ = std::fs::remove_file(&output_name);
+        assert_eq!(written_bytes, expected_bytes);
     }
 
     #[cfg(unix)]
@@ -1747,12 +2021,15 @@ mod tests {
         let step = crate::RunStep {
             kind: "agent".to_string(),
             program: None,
+            model: None,
             output_variable: None,
             status_variable: None,
             error_variable: None,
             failure_mode: None,
             when: None,
             args: Vec::new(),
+            prompt: None,
+            path: None,
             subject: None,
             text: None,
             agent: Some(format!("./{}", script_name)),
@@ -1849,6 +2126,7 @@ mod tests {
         let exec_step = crate::RunStep {
             kind: "exec".to_string(),
             program: Some("/bin/sh".to_string()),
+            model: None,
             output_variable: Some("report_listing".to_string()),
             status_variable: None,
             error_variable: None,
@@ -1858,6 +2136,8 @@ mod tests {
                 crate::RunArg::Literal("-lc".to_string()),
                 crate::RunArg::Literal("printf 'q1.pdf | q2.pdf\\n'".to_string()),
             ],
+            prompt: None,
+            path: None,
             subject: None,
             text: None,
             agent: None,
@@ -1868,12 +2148,15 @@ mod tests {
         let agent_step = crate::RunStep {
             kind: "agent".to_string(),
             program: None,
+            model: None,
             output_variable: None,
             status_variable: None,
             error_variable: None,
             failure_mode: None,
             when: None,
             args: Vec::new(),
+            prompt: None,
+            path: None,
             subject: None,
             text: None,
             agent: Some(format!("./{}", script_name)),
@@ -1953,12 +2236,15 @@ mod tests {
         let step = crate::RunStep {
             kind: "agent".to_string(),
             program: None,
+            model: None,
             output_variable: None,
             status_variable: None,
             error_variable: None,
             failure_mode: None,
             when: None,
             args: Vec::new(),
+            prompt: None,
+            path: None,
             subject: None,
             text: None,
             agent: Some(format!("./{}", script_name)),
@@ -1992,12 +2278,15 @@ mod tests {
         let step = crate::RunStep {
             kind: "agent".to_string(),
             program: None,
+            model: None,
             output_variable: None,
             status_variable: None,
             error_variable: None,
             failure_mode: None,
             when: None,
             args: Vec::new(),
+            prompt: None,
+            path: None,
             subject: None,
             text: None,
             agent: Some("child_agent".to_string()),
@@ -2019,12 +2308,15 @@ mod tests {
         let step = crate::RunStep {
             kind: "agent".to_string(),
             program: None,
+            model: None,
             output_variable: None,
             status_variable: None,
             error_variable: None,
             failure_mode: None,
             when: None,
             args: Vec::new(),
+            prompt: None,
+            path: None,
             subject: None,
             text: None,
             agent: Some("./../child_agent".to_string()),
@@ -2046,12 +2338,15 @@ mod tests {
         let step = crate::RunStep {
             kind: "agent".to_string(),
             program: None,
+            model: None,
             output_variable: None,
             status_variable: None,
             error_variable: None,
             failure_mode: None,
             when: None,
             args: Vec::new(),
+            prompt: None,
+            path: None,
             subject: None,
             text: None,
             agent: Some("./agents/child_agent".to_string()),
@@ -2090,12 +2385,15 @@ mod tests {
         let step = crate::RunStep {
             kind: "agent".to_string(),
             program: None,
+            model: None,
             output_variable: None,
             status_variable: None,
             error_variable: None,
             failure_mode: None,
             when: None,
             args: Vec::new(),
+            prompt: None,
+            path: None,
             subject: None,
             text: None,
             agent: Some(format!("./{}", script_name)),
@@ -2138,6 +2436,7 @@ mod tests {
         let failing_step = crate::RunStep {
             kind: "exec".to_string(),
             program: Some("/bin/sh".to_string()),
+            model: None,
             output_variable: None,
             status_variable: Some("step_status".to_string()),
             error_variable: Some("step_error".to_string()),
@@ -2147,6 +2446,8 @@ mod tests {
                 crate::RunArg::Literal("-lc".to_string()),
                 crate::RunArg::Literal("exit 7".to_string()),
             ],
+            prompt: None,
+            path: None,
             subject: None,
             text: None,
             agent: None,
@@ -2157,12 +2458,15 @@ mod tests {
         let second_step = crate::RunStep {
             kind: "agent".to_string(),
             program: None,
+            model: None,
             output_variable: None,
             status_variable: None,
             error_variable: None,
             failure_mode: None,
             when: None,
             args: Vec::new(),
+            prompt: None,
+            path: None,
             subject: None,
             text: None,
             agent: Some(format!("./{}", script_name)),
@@ -2175,6 +2479,7 @@ mod tests {
         let result = apply_actions(
             &crate::Output { answer: 4 },
             &[action(vec![failing_step, second_step])],
+            &provider_context(),
             5,
             runtime_budget,
         )
@@ -2216,6 +2521,7 @@ mod tests {
         let failing_step = crate::RunStep {
             kind: "exec".to_string(),
             program: Some("/bin/sh".to_string()),
+            model: None,
             output_variable: None,
             status_variable: Some("step_status".to_string()),
             error_variable: Some("step_error".to_string()),
@@ -2225,6 +2531,8 @@ mod tests {
                 crate::RunArg::Literal("-lc".to_string()),
                 crate::RunArg::Literal("exit 9".to_string()),
             ],
+            prompt: None,
+            path: None,
             subject: None,
             text: None,
             agent: None,
@@ -2235,12 +2543,15 @@ mod tests {
         let second_step = crate::RunStep {
             kind: "agent".to_string(),
             program: None,
+            model: None,
             output_variable: None,
             status_variable: None,
             error_variable: None,
             failure_mode: None,
             when: Some(json!({ "==": [{ "var": "step_status" }, "failed"] })),
             args: Vec::new(),
+            prompt: None,
+            path: None,
             subject: None,
             text: None,
             agent: Some(format!("./{}", script_name)),
@@ -2253,6 +2564,7 @@ mod tests {
         let result = apply_actions(
             &crate::Output { answer: 4 },
             &[action(vec![failing_step, second_step])],
+            &provider_context(),
             5,
             runtime_budget,
         )

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -12,7 +12,9 @@ pub(crate) use error::{
     ProviderError, ProviderKind,
 };
 pub(crate) use ollama::send_request as send_ollama_request;
-pub(crate) use openai::send_request as send_openai_request;
+pub(crate) use openai::{
+    send_image_request as send_openai_image_request, send_request as send_openai_request,
+};
 pub(crate) use runtime::{
     resolve_inputs as resolve_provider_inputs, Cargo as AgentCargo, ValidatedResponse,
 };

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -1,5 +1,6 @@
 // External Crates
 use super::{runtime::ContentPart, ProviderError, ProviderKind};
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use reqwest::ClientBuilder;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -37,6 +38,24 @@ pub struct ImageUrl {
 pub struct FileInput {
     pub filename: String,
     pub file_data: String,
+}
+
+#[derive(Serialize, Debug)]
+struct ImageGenerationRequest {
+    model: String,
+    prompt: String,
+    n: u8,
+    output_format: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct ImageGenerationResponse {
+    data: Vec<ImageGenerationData>,
+}
+
+#[derive(Deserialize, Debug)]
+struct ImageGenerationData {
+    b64_json: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -81,6 +100,19 @@ fn normalize_chatgpt_responses_url(url: &str) -> String {
         trimmed.to_string()
     } else {
         format!("{trimmed}/responses")
+    }
+}
+
+fn normalize_openai_images_url(url: &str) -> Result<String, ProviderError> {
+    let trimmed = url.trim_end_matches('/');
+    if let Some(index) = trimmed.find("/v1/") {
+        return Ok(format!("{}/v1/images/generations", &trimmed[..index]));
+    }
+
+    if trimmed.ends_with("/v1") {
+        Ok(format!("{trimmed}/images/generations"))
+    } else {
+        Ok(format!("{trimmed}/v1/images/generations"))
     }
 }
 
@@ -148,6 +180,30 @@ fn parse_stream_failure_message(payload: &serde_json::Value) -> Option<String> {
                 .and_then(serde_json::Value::as_str)
                 .map(str::to_string)
         })
+}
+
+fn find_image_generation_result(payload: &serde_json::Value) -> Option<&str> {
+    match payload {
+        serde_json::Value::Object(map) => {
+            let is_image_generation_call =
+                map.get("type").and_then(serde_json::Value::as_str)
+                    == Some("image_generation_call");
+            if is_image_generation_call {
+                if let Some(result) = map
+                    .get("result")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                {
+                    return Some(result);
+                }
+            }
+
+            map.values().find_map(find_image_generation_result)
+        }
+        serde_json::Value::Array(items) => items.iter().find_map(find_image_generation_result),
+        _ => None,
+    }
 }
 
 async fn send_chat_completions_request(
@@ -350,6 +406,120 @@ async fn send_chatgpt_codex_responses_request(
     ))
 }
 
+async fn send_chatgpt_codex_image_request(
+    url: &String,
+    model: &String,
+    prompt: &str,
+    timeout_in_sec: u64,
+    token: &String,
+    output_format: &str,
+) -> Result<Vec<u8>, ProviderError> {
+    let client = ClientBuilder::new()
+        .timeout(Duration::from_secs(timeout_in_sec))
+        .build()
+        .map_err(|error| ProviderError::from_reqwest(ProviderKind::OpenAi, error))?;
+
+    let request_payload = serde_json::json!({
+        "model": model,
+        "instructions": "Generate the requested image and return it using the image_generation tool.",
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": prompt
+                    }
+                ]
+            }
+        ],
+        "tools": [
+            {
+                "type": "image_generation",
+                "output_format": output_format
+            }
+        ],
+        "store": false,
+        "stream": true
+    });
+
+    let endpoint = normalize_chatgpt_responses_url(url);
+    let http_resp = client
+        .post(endpoint.as_str())
+        .header("Authorization", format!("Bearer {}", token))
+        .header("Content-Type", "application/json")
+        .json(&request_payload)
+        .send()
+        .await
+        .map_err(|error| ProviderError::from_reqwest(ProviderKind::OpenAi, error))?;
+
+    let status = http_resp.status();
+    let raw_stream = http_resp
+        .text()
+        .await
+        .map_err(|error| ProviderError::from_reqwest(ProviderKind::OpenAi, error))?;
+
+    if !status.is_success() {
+        return Err(ProviderError::from_http_status(
+            ProviderKind::OpenAi,
+            status,
+            raw_stream.as_str(),
+        ));
+    }
+
+    let mut encoded_image: Option<String> = None;
+
+    for raw_line in raw_stream.lines() {
+        let line = raw_line.trim_end_matches('\r');
+        let Some(payload) = line.strip_prefix("data: ") else {
+            continue;
+        };
+        if payload.trim().is_empty() || payload.trim() == "[DONE]" {
+            continue;
+        }
+
+        let event_json = serde_json::from_str::<serde_json::Value>(payload).map_err(|error| {
+            ProviderError::invalid_response(
+                ProviderKind::OpenAi,
+                format!("Failed to parse streaming payload: {error}\nPayload: {payload}"),
+            )
+        })?;
+
+        if let Some(result) = find_image_generation_result(&event_json) {
+            encoded_image = Some(result.to_string());
+            continue;
+        }
+
+        let event_type = event_json
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("");
+
+        if event_type == "response.failed" || event_type == "error" {
+            let detail =
+                parse_stream_failure_message(&event_json).unwrap_or_else(|| payload.to_string());
+            return Err(ProviderError::invalid_response(
+                ProviderKind::OpenAi,
+                format!("OpenAI stream failed: {detail}"),
+            ));
+        }
+    }
+
+    let encoded_image = encoded_image.ok_or_else(|| {
+        ProviderError::invalid_response(
+            ProviderKind::OpenAi,
+            "Image generation stream did not include an `image_generation_call` result payload.",
+        )
+    })?;
+
+    BASE64_STANDARD.decode(encoded_image).map_err(|error| {
+        ProviderError::invalid_response(
+            ProviderKind::OpenAi,
+            format!("Failed to decode generated image bytes: {error}"),
+        )
+    })
+}
+
 pub async fn send_request(
     url: &String,
     model: &String,
@@ -379,6 +549,92 @@ pub async fn send_request(
         )
         .await
     }
+}
+
+pub async fn send_image_request(
+    url: &String,
+    model: &String,
+    prompt: &str,
+    timeout_in_sec: u64,
+    token: &String,
+    output_format: &str,
+) -> Result<Vec<u8>, ProviderError> {
+    if is_chatgpt_codex_responses_endpoint(url) {
+        return send_chatgpt_codex_image_request(
+            url,
+            model,
+            prompt,
+            timeout_in_sec,
+            token,
+            output_format,
+        )
+        .await;
+    }
+
+    let endpoint = normalize_openai_images_url(url)?;
+    let client = ClientBuilder::new()
+        .timeout(Duration::from_secs(timeout_in_sec))
+        .build()
+        .map_err(|error| ProviderError::from_reqwest(ProviderKind::OpenAi, error))?;
+
+    let request = ImageGenerationRequest {
+        model: model.clone(),
+        prompt: prompt.to_string(),
+        n: 1,
+        output_format: output_format.to_string(),
+    };
+
+    let http_resp = client
+        .post(endpoint.as_str())
+        .header("Authorization", format!("Bearer {}", token))
+        .header("Content-Type", "application/json")
+        .json(&request)
+        .send()
+        .await
+        .map_err(|error| ProviderError::from_reqwest(ProviderKind::OpenAi, error))?;
+
+    let status = http_resp.status();
+    let body_bytes = http_resp
+        .bytes()
+        .await
+        .map_err(|error| ProviderError::from_reqwest(ProviderKind::OpenAi, error))?;
+
+    if !status.is_success() {
+        let raw = String::from_utf8_lossy(&body_bytes);
+        return Err(ProviderError::from_http_status(
+            ProviderKind::OpenAi,
+            status,
+            &raw,
+        ));
+    }
+
+    let response: ImageGenerationResponse =
+        serde_json::from_slice(&body_bytes).map_err(|error| {
+            let raw = String::from_utf8_lossy(&body_bytes);
+            ProviderError::invalid_response(
+                ProviderKind::OpenAi,
+                format!("Failed to parse image-generation JSON: {error}\nRaw response:\n{raw}"),
+            )
+        })?;
+
+    let encoded_image = response
+        .data
+        .first()
+        .map(|image| image.b64_json.trim())
+        .filter(|image| !image.is_empty())
+        .ok_or_else(|| {
+            ProviderError::invalid_response(
+                ProviderKind::OpenAi,
+                "Image generation response did not include `data[0].b64_json`.",
+            )
+        })?;
+
+    BASE64_STANDARD.decode(encoded_image).map_err(|error| {
+        ProviderError::invalid_response(
+            ProviderKind::OpenAi,
+            format!("Failed to decode generated image bytes: {error}"),
+        )
+    })
 }
 
 fn chat_request_content_parts(content_parts: &[ContentPart]) -> Vec<ChatRequestContentPart> {
@@ -431,10 +687,11 @@ fn responses_request_content_parts(content_parts: &[ContentPart]) -> Vec<serde_j
 #[cfg(test)]
 mod tests {
     use super::{
-        chat_request_content_parts, responses_request_content_parts, send_request,
-        ChatRequestContentPart,
+        chat_request_content_parts, responses_request_content_parts, send_image_request,
+        send_request, ChatRequestContentPart,
     };
     use crate::providers::runtime::ContentPart;
+    use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 
     #[test]
     fn chat_request_content_parts_encode_pdf_files() {
@@ -513,5 +770,72 @@ mod tests {
             .await
             .expect("stream response should parse");
         assert_eq!(response, "{\"answer\":\"hi\"}");
+    }
+
+    #[tokio::test]
+    async fn image_request_uses_images_endpoint_and_decodes_bytes() {
+        let mut server = mockito::Server::new_async().await;
+        let expected_bytes = b"fake-png";
+        let encoded_image = BASE64_STANDARD.encode(expected_bytes);
+        let _mock = server
+            .mock("POST", "/v1/images/generations")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(
+                r#"{{"data":[{{"b64_json":"{}"}}]}}"#,
+                encoded_image
+            ))
+            .create_async()
+            .await;
+
+        let url = format!("{}/v1/chat/completions", server.url());
+        let model = "gpt-image-1".to_string();
+        let token = "test-token".to_string();
+
+        let image = send_image_request(&url, &model, "draw a square", 10, &token, "png")
+            .await
+            .expect("image request should decode");
+
+        assert_eq!(image, expected_bytes);
+    }
+
+    #[tokio::test]
+    async fn image_request_uses_chatgpt_responses_tool_and_decodes_bytes() {
+        let mut server = mockito::Server::new_async().await;
+        let expected_bytes = b"fake-webp";
+        let encoded_image = BASE64_STANDARD.encode(expected_bytes);
+        let _mock = server
+            .mock("POST", "/chatgpt.com/backend-api/codex/responses")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "model": "gpt-5.2",
+                "tools": [
+                    {
+                        "type": "image_generation",
+                        "output_format": "webp"
+                    }
+                ],
+                "store": false,
+                "stream": true
+            })))
+            .with_status(200)
+            .with_header("content-type", "text/event-stream")
+            .with_body(format!(
+                "event: response.output_item.done\n\
+data: {{\"item\":{{\"type\":\"image_generation_call\",\"result\":\"{}\"}}}}\n\n\
+data: [DONE]\n",
+                encoded_image,
+            ))
+            .create_async()
+            .await;
+
+        let url = format!("{}/chatgpt.com/backend-api/codex", server.url());
+        let model = "gpt-5.2".to_string();
+        let token = "test-token".to_string();
+
+        let image = send_image_request(&url, &model, "draw a square", 10, &token, "webp")
+            .await
+            .expect("chatgpt account transport should decode image bytes");
+
+        assert_eq!(image, expected_bytes);
     }
 }

--- a/templates/build_support.rs
+++ b/templates/build_support.rs
@@ -25,6 +25,8 @@ const SUPPORTED_FILE_EXTENSIONS: [&str; 24] = [
     "doc", "dot", "odt", "rtf", "pot", "ppa", "pps", "ppt", "pptx", "pwz", "wiz",
 ];
 const SUPPORTED_FILE_EXTENSIONS_MESSAGE: &str = "`.pdf`, `.docx`, `.csv`, `.xla`, `.xlb`, `.xlc`, `.xlm`, `.xls`, `.xlsx`, `.xlt`, `.xlw`, `.tsv`, `.iif`, `.doc`, `.dot`, `.odt`, `.rtf`, `.pot`, `.ppa`, `.pps`, `.ppt`, `.pptx`, `.pwz`, `.wiz`";
+const SUPPORTED_GENERATED_IMAGE_EXTENSIONS: [&str; 4] = ["png", "jpg", "jpeg", "webp"];
+const SUPPORTED_GENERATED_IMAGE_EXTENSIONS_MESSAGE: &str = "`.png`, `.jpg`, `.jpeg`, `.webp`";
 
 #[derive(Debug)]
 pub enum BuildError {
@@ -109,12 +111,15 @@ enum ActionInputSpec {
 struct RunStep {
     kind: String,
     program: Option<String>,
+    model: Option<String>,
     output_variable: Option<String>,
     status_variable: Option<String>,
     error_variable: Option<String>,
     failure_mode: Option<FailureMode>,
     when: Option<Value>,
     args: Vec<RunArg>,
+    prompt: Option<Vec<RunArg>>,
+    path: Option<Vec<RunArg>>,
     subject: Option<Vec<RunArg>>,
     text: Option<Vec<RunArg>>,
     agent: Option<String>,
@@ -630,6 +635,24 @@ fn parse_actions(
 
             let run_step = match kind.as_str() {
                 "exec" => {
+                    if run_obj.contains_key("model") {
+                        return Err(BuildError::config(
+                            format!("{run_path}.model"),
+                            "`model` is only supported for `generate_image` actions",
+                        ));
+                    }
+                    if run_obj.contains_key("prompt") {
+                        return Err(BuildError::config(
+                            format!("{run_path}.prompt"),
+                            "`prompt` is only supported for `generate_image` actions",
+                        ));
+                    }
+                    if run_obj.contains_key("path") {
+                        return Err(BuildError::config(
+                            format!("{run_path}.path"),
+                            "`path` is only supported for `generate_image` actions",
+                        ));
+                    }
                     if run_obj.contains_key("subject") {
                         return Err(BuildError::config(
                             format!("{run_path}.subject"),
@@ -680,12 +703,15 @@ fn parse_actions(
                     RunStep {
                         kind,
                         program: Some(program),
+                        model: None,
                         output_variable,
                         status_variable,
                         error_variable,
                         failure_mode,
                         when,
                         args,
+                        prompt: None,
+                        path: None,
                         subject: None,
                         text: None,
                         agent: None,
@@ -695,6 +721,24 @@ fn parse_actions(
                     }
                 }
                 "email_me" => {
+                    if run_obj.contains_key("model") {
+                        return Err(BuildError::config(
+                            format!("{run_path}.model"),
+                            "`model` is only supported for `generate_image` actions",
+                        ));
+                    }
+                    if run_obj.contains_key("prompt") {
+                        return Err(BuildError::config(
+                            format!("{run_path}.prompt"),
+                            "`prompt` is only supported for `generate_image` actions",
+                        ));
+                    }
+                    if run_obj.contains_key("path") {
+                        return Err(BuildError::config(
+                            format!("{run_path}.path"),
+                            "`path` is only supported for `generate_image` actions",
+                        ));
+                    }
                     if run_obj.contains_key("program") {
                         return Err(BuildError::config(
                             format!("{run_path}.program"),
@@ -748,12 +792,15 @@ fn parse_actions(
                     RunStep {
                         kind,
                         program: None,
+                        model: None,
                         output_variable: None,
                         status_variable,
                         error_variable,
                         failure_mode,
                         when,
                         args: Vec::new(),
+                        prompt: None,
+                        path: None,
                         subject: Some(subject),
                         text: Some(text),
                         agent: None,
@@ -763,6 +810,24 @@ fn parse_actions(
                     }
                 }
                 "agent" => {
+                    if run_obj.contains_key("model") {
+                        return Err(BuildError::config(
+                            format!("{run_path}.model"),
+                            "`model` is only supported for `generate_image` actions",
+                        ));
+                    }
+                    if run_obj.contains_key("prompt") {
+                        return Err(BuildError::config(
+                            format!("{run_path}.prompt"),
+                            "`prompt` is only supported for `generate_image` actions",
+                        ));
+                    }
+                    if run_obj.contains_key("path") {
+                        return Err(BuildError::config(
+                            format!("{run_path}.path"),
+                            "`path` is only supported for `generate_image` actions",
+                        ));
+                    }
                     if run_obj.contains_key("program") {
                         return Err(BuildError::config(
                             format!("{run_path}.program"),
@@ -829,12 +894,15 @@ fn parse_actions(
                     RunStep {
                         kind,
                         program: None,
+                        model: None,
                         output_variable: None,
                         status_variable,
                         error_variable,
                         failure_mode,
                         when,
                         args: Vec::new(),
+                        prompt: None,
+                        path: None,
                         subject: None,
                         text: None,
                         agent: Some(agent),
@@ -843,11 +911,114 @@ fn parse_actions(
                         platforms,
                     }
                 }
+                "generate_image" => {
+                    if run_obj.contains_key("program") {
+                        return Err(BuildError::config(
+                            format!("{run_path}.program"),
+                            "`program` is not supported for `generate_image` actions",
+                        ));
+                    }
+                    if run_obj.contains_key("args") {
+                        return Err(BuildError::config(
+                            format!("{run_path}.args"),
+                            "`args` is not supported for `generate_image` actions",
+                        ));
+                    }
+                    if run_obj.contains_key("subject") {
+                        return Err(BuildError::config(
+                            format!("{run_path}.subject"),
+                            "`subject` is not supported for `generate_image` actions",
+                        ));
+                    }
+                    if run_obj.contains_key("text") {
+                        return Err(BuildError::config(
+                            format!("{run_path}.text"),
+                            "`text` is not supported for `generate_image` actions",
+                        ));
+                    }
+                    if run_obj.contains_key("agent") {
+                        return Err(BuildError::config(
+                            format!("{run_path}.agent"),
+                            "`agent` is not supported for `generate_image` actions",
+                        ));
+                    }
+                    if run_obj.contains_key("inputs") {
+                        return Err(BuildError::config(
+                            format!("{run_path}.inputs"),
+                            "`inputs` is not supported for `generate_image` actions",
+                        ));
+                    }
+                    if run_obj.contains_key("output_variable") {
+                        return Err(BuildError::config(
+                            format!("{run_path}.output_variable"),
+                            "`output_variable` is not supported for `generate_image` actions",
+                        ));
+                    }
+                    if run_obj.contains_key("input_mode") {
+                        return Err(BuildError::config(
+                            format!("{run_path}.input_mode"),
+                            "`input_mode` is only supported for `agent` actions",
+                        ));
+                    }
+
+                    let model = get_required_string(run_obj, "model", &run_path)?.to_string();
+                    if model.trim().is_empty() {
+                        return Err(BuildError::config(
+                            format!("{run_path}.model"),
+                            "must be a non-empty string",
+                        ));
+                    }
+
+                    let prompt = parse_string_parts_field(
+                        run_obj,
+                        "prompt",
+                        &run_path,
+                        &available_field_types,
+                    )?;
+                    let path = parse_string_parts_field(
+                        run_obj,
+                        "path",
+                        &run_path,
+                        &available_field_types,
+                    )?;
+                    if let Some(resolved_path) = resolve_literal_run_args(&path) {
+                        validate_definition_owned_local_path(
+                            &resolved_path,
+                            &format!("{run_path}.path"),
+                            "generated image output",
+                        )?;
+                        validate_generated_image_output_extension(
+                            &resolved_path,
+                            &format!("{run_path}.path"),
+                            "generated image output",
+                        )?;
+                    }
+
+                    RunStep {
+                        kind,
+                        program: None,
+                        model: Some(model),
+                        output_variable: None,
+                        status_variable,
+                        error_variable,
+                        failure_mode,
+                        when,
+                        args: Vec::new(),
+                        prompt: Some(prompt),
+                        path: Some(path),
+                        subject: None,
+                        text: None,
+                        agent: None,
+                        inputs: None,
+                        input_mode: None,
+                        platforms,
+                    }
+                }
                 _ => {
                     return Err(BuildError::config(
                         format!("{run_path}.kind"),
                         format!(
-                            "unsupported kind `{kind}` (supported: `exec`, `email_me`, `agent`)"
+                            "unsupported kind `{kind}` (supported: `exec`, `email_me`, `agent`, `generate_image`)"
                         ),
                     ));
                 }
@@ -1269,6 +1440,27 @@ fn validate_supported_file_extension(
             path,
             format!(
                 "{label} path must use a supported extension: {SUPPORTED_FILE_EXTENSIONS_MESSAGE}"
+            ),
+        )),
+    }
+}
+
+fn validate_generated_image_output_extension(
+    raw_path: &str,
+    path: &str,
+    label: &str,
+) -> Result<(), BuildError> {
+    let extension = Path::new(raw_path)
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(|value| value.to_ascii_lowercase());
+
+    match extension.as_deref() {
+        Some(extension) if SUPPORTED_GENERATED_IMAGE_EXTENSIONS.contains(&extension) => Ok(()),
+        _ => Err(BuildError::config(
+            path,
+            format!(
+                "{label} path must use a supported extension: {SUPPORTED_GENERATED_IMAGE_EXTENSIONS_MESSAGE}"
             ),
         )),
     }
@@ -2290,6 +2482,16 @@ fn render_agent_model(config: &AgentConfig) -> String {
             .iter()
             .map(|run_step| {
                 let args = render_run_arg_parts(&run_step.args);
+                let prompt = run_step
+                    .prompt
+                    .as_ref()
+                    .map(|parts| format!("Some(vec![{}])", render_run_arg_parts(parts)))
+                    .unwrap_or_else(|| "None".to_string());
+                let path = run_step
+                    .path
+                    .as_ref()
+                    .map(|parts| format!("Some(vec![{}])", render_run_arg_parts(parts)))
+                    .unwrap_or_else(|| "None".to_string());
                 let subject = run_step
                     .subject
                     .as_ref()
@@ -2302,6 +2504,11 @@ fn render_agent_model(config: &AgentConfig) -> String {
                     .unwrap_or_else(|| "None".to_string());
                 let output_variable = run_step
                     .output_variable
+                    .as_ref()
+                    .map(|name| format!("Some({}.to_string())", rust_string_literal(name)))
+                    .unwrap_or_else(|| "None".to_string());
+                let model = run_step
+                    .model
                     .as_ref()
                     .map(|name| format!("Some({}.to_string())", rust_string_literal(name)))
                     .unwrap_or_else(|| "None".to_string());
@@ -2395,12 +2602,15 @@ fn render_agent_model(config: &AgentConfig) -> String {
                     "RunStep {{
                         kind: {}.to_string(),
                         program: {},
+                        model: {},
                         output_variable: {},
                         status_variable: {},
                         error_variable: {},
                         failure_mode: {},
                         when: {},
                         args: vec![{}],
+                        prompt: {},
+                        path: {},
                         subject: {},
                         text: {},
                         agent: {},
@@ -2416,12 +2626,15 @@ fn render_agent_model(config: &AgentConfig) -> String {
                             format!("Some({}.to_string())", rust_string_literal(program))
                         })
                         .unwrap_or_else(|| "None".to_string()),
+                    model,
                     output_variable,
                     status_variable,
                     error_variable,
                     failure_mode,
                     when,
                     args,
+                    prompt,
+                    path,
                     subject,
                     text,
                     agent,
@@ -2534,12 +2747,15 @@ pub enum ActionInputMode {{
 pub struct RunStep {{
     kind: String,
     program: Option<String>,
+    model: Option<String>,
     output_variable: Option<String>,
     status_variable: Option<String>,
     error_variable: Option<String>,
     failure_mode: Option<FailureMode>,
     when: Option<serde_json::Value>,
     args: Vec<RunArg>,
+    prompt: Option<Vec<RunArg>>,
+    path: Option<Vec<RunArg>>,
     subject: Option<Vec<RunArg>>,
     text: Option<Vec<RunArg>>,
     agent: Option<String>,

--- a/templates/guidance/action-rules.md
+++ b/templates/guidance/action-rules.md
@@ -24,6 +24,10 @@ These documented step kinds and helper fields are exhaustive for the current MVP
   - Required: `kind`, `agent`
 - `email_me`
   - Required: `kind`, `subject`, `text`
+- `generate_image`
+  - Required: `kind`, `model`, `prompt`, `path`
+  - First slice: OpenAI-backed single-image output only
+  - Use a tool-capable mainline model such as `gpt-5.2` for OpenAI account transport, or an image model such as `gpt-image-1` for direct OpenAI API transport
 
 ## Optional Control Fields
 - `when`
@@ -76,6 +80,7 @@ These documented step kinds and helper fields are exhaustive for the current MVP
 - Child agents must use explicit same-level paths such as `./child_reporter`.
 - Local file and image paths should stay relative.
 - Parent-directory traversal such as `../` is invalid.
+- `generate_image` output paths must use one of: `.png`, `.jpg`, `.jpeg`, `.webp`.
 
 ## Child-Agent Data Flow
 

--- a/templates/guidance/agent-definition-contract.md
+++ b/templates/guidance/agent-definition-contract.md
@@ -134,6 +134,17 @@ Required fields:
 - `subject`
 - `text`
 
+### `generate_image`
+
+Required fields:
+- `kind`
+- `model`
+- `prompt`
+- `path`
+- First slice writes one local image file.
+- For the default OpenAI account transport, use a tool-capable mainline model such as `gpt-5.2`.
+- For a direct OpenAI API token and URL, use an image model such as `gpt-image-1`.
+
 ## Common Optional Step Fields
 
 These fields are available on every step kind:
@@ -173,7 +184,7 @@ Example:
 
 - The top-level `agent_schema` fields are the agent's returned structured output.
 - Actions run after the model has produced that top-level output.
-- `exec`, `agent`, and `email_me` steps are follow-up side effects or orchestration.
+- `exec`, `agent`, `email_me`, and `generate_image` steps are follow-up side effects or orchestration.
 - Action steps do not mutate the returned top-level output object.
 - `output_variable`, `status_variable`, and `error_variable` are action-local only.
 
@@ -238,6 +249,7 @@ Expect `cargo ai hatch <agent-name> --config <config.json> --check` to reject at
 - invalid child-agent path shape
 - invalid child-agent `input_mode`
 - invalid relative file or image paths
+- invalid generated-image output path extension
 - invalid `platform` value
 - `output_variable` on non-`exec` steps
 - captured-variable collisions

--- a/templates/src/main.rs
+++ b/templates/src/main.rs
@@ -74,6 +74,14 @@ struct InvocationRuntimeBudget {
     deadline_ms: u64,
 }
 
+#[derive(Debug, Clone)]
+struct ActionProviderContext {
+    provider: ProviderKind,
+    url: String,
+    token: String,
+    inference_timeout_in_sec: u64,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum StepExecutionOutcome {
     Completed,
@@ -1136,8 +1144,22 @@ async fn main() {
     };
 
     let actions = actions();
+    let action_provider_context = ActionProviderContext {
+        provider,
+        url: url.clone(),
+        token: token.clone(),
+        inference_timeout_in_sec,
+    };
     if let Err(error) =
-        apply_actions(&output, &actions, config.as_ref(), max_agent_depth, runtime_budget).await
+        apply_actions(
+            &output,
+            &actions,
+            config.as_ref(),
+            &action_provider_context,
+            max_agent_depth,
+            runtime_budget,
+        )
+        .await
     {
         eprintln!("❌ {error}");
         std::process::exit(1);
@@ -1148,6 +1170,7 @@ async fn apply_actions(
     output: &Output,
     actions: &[Action],
     config: Option<&config::schema::Config>,
+    provider_context: &ActionProviderContext,
     max_agent_depth: u32,
     runtime_budget: InvocationRuntimeBudget,
 ) -> Result<(), String> {
@@ -1200,6 +1223,16 @@ async fn apply_actions(
                             &action_data,
                             &action.name,
                             max_agent_depth,
+                            runtime_budget,
+                        )
+                        .await
+                        .map(|outcome| (outcome, None))
+                    } else if step.kind.eq_ignore_ascii_case("generate_image") {
+                        run_generate_image_step(
+                            step,
+                            &action_data,
+                            &action.name,
+                            provider_context,
                             runtime_budget,
                         )
                         .await
@@ -1485,6 +1518,128 @@ async fn run_email_me_step(
     } else {
         StepExecutionOutcome::Completed
     })
+}
+
+async fn run_generate_image_step(
+    step: &RunStep,
+    data: &serde_json::Value,
+    action_name: &str,
+    provider_context: &ActionProviderContext,
+    runtime_budget: InvocationRuntimeBudget,
+) -> Result<StepExecutionOutcome, String> {
+    if provider_context.provider != ProviderKind::OpenAi {
+        return Err(format!(
+            "Action '{}' generate_image step requires `--server openai`; current server is {}.",
+            action_name,
+            provider_context.provider.display_name()
+        ));
+    }
+
+    let model = step.model.as_ref().ok_or_else(|| {
+        format!(
+            "Action '{}' generate_image step is missing required `model`.",
+            action_name
+        )
+    })?;
+
+    if provider_context.url.contains("chatgpt.com/backend-api/codex")
+        && model.starts_with("gpt-image")
+    {
+        return Err(format!(
+            "Action '{}' generate_image step uses OpenAI account transport, so `model` must be a tool-capable mainline model such as `gpt-5.2`, not '{}'.",
+            action_name, model
+        ));
+    }
+    let prompt_parts = step.prompt.as_deref().ok_or_else(|| {
+        format!(
+            "Action '{}' generate_image step is missing required `prompt`.",
+            action_name
+        )
+    })?;
+    let path_parts = step.path.as_deref().ok_or_else(|| {
+        format!(
+            "Action '{}' generate_image step is missing required `path`.",
+            action_name
+        )
+    })?;
+
+    let prompt = resolve_string_parts(prompt_parts, data, action_name, "prompt")
+        .map_err(|error| format!("Action '{}': {error}", action_name))?;
+    let output_path = resolve_string_parts(path_parts, data, action_name, "path")
+        .map_err(|error| format!("Action '{}': {error}", action_name))?;
+    let output_format = generated_image_output_format(output_path.as_str(), action_name)?;
+
+    let remaining = remaining_runtime_duration(
+        runtime_budget,
+        &format!("before starting image generation with model '{}'", model),
+    )
+    .map_err(|context| {
+        action_runtime_timeout_message(
+            action_name,
+            runtime_budget,
+            context.as_str(),
+        )
+    })?;
+
+    let image_bytes = match tokio::time::timeout(
+        remaining,
+        crate::providers::send_openai_image_request(
+            &provider_context.url,
+            model,
+            prompt.as_str(),
+            provider_context.inference_timeout_in_sec,
+            &provider_context.token,
+            output_format,
+        ),
+    )
+    .await
+    {
+        Ok(Ok(bytes)) => bytes,
+        Ok(Err(error)) => {
+            let mut lines =
+                vec![format!("Action '{}' generate_image step failed.", action_name)];
+            lines.extend(provider_error_messages(&error));
+            return Err(lines.join("\n"));
+        }
+        Err(_) => {
+            return Err(action_runtime_timeout_message(
+                action_name,
+                runtime_budget,
+                "while waiting for image generation",
+            ));
+        }
+    };
+
+    let output_path_ref = Path::new(output_path.as_str());
+    validate_generated_image_output_path(output_path_ref, action_name)?;
+    if let Some(parent) = output_path_ref.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                format!(
+                    "Action '{}' failed to create image output directory '{}': {}",
+                    action_name,
+                    parent.display(),
+                    error
+                )
+            })?;
+        }
+    }
+
+    std::fs::write(output_path_ref, image_bytes).map_err(|error| {
+        format!(
+            "Action '{}' failed to write generated image '{}': {}",
+            action_name,
+            output_path_ref.display(),
+            error
+        )
+    })?;
+
+    println!(
+        "ℹ️ Action '{}' wrote generated image to '{}'.",
+        action_name,
+        output_path_ref.display()
+    );
+    Ok(StepExecutionOutcome::Completed)
 }
 
 async fn run_agent_step(
@@ -1942,6 +2097,50 @@ fn child_input_args(
 
 fn child_input_uses_dynamic_parts(parts: &[RunArg]) -> bool {
     parts.iter().any(|part| matches!(part, RunArg::Variable(_)))
+}
+
+fn validate_generated_image_output_path(path: &Path, action_name: &str) -> Result<(), String> {
+    let raw_path = path.to_string_lossy();
+    if raw_path.trim().is_empty() {
+        return Err(format!(
+            "Action '{}' generate_image `path` must resolve to a non-empty relative path.",
+            action_name
+        ));
+    }
+    if path.is_absolute() {
+        return Err(format!(
+            "Action '{}' generate_image `path` must resolve to a relative path.",
+            action_name
+        ));
+    }
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(format!(
+            "Action '{}' generate_image `path` must not use parent traversal (`..`).",
+            action_name
+        ));
+    }
+
+    generated_image_output_format(raw_path.as_ref(), action_name).map(|_| ())
+}
+
+fn generated_image_output_format(raw_path: &str, action_name: &str) -> Result<&'static str, String> {
+    let extension = Path::new(raw_path)
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(|value| value.to_ascii_lowercase());
+
+    match extension.as_deref() {
+        Some("png") => Ok("png"),
+        Some("jpg") | Some("jpeg") => Ok("jpeg"),
+        Some("webp") => Ok("webp"),
+        _ => Err(format!(
+            "Action '{}' generate_image `path` must use a supported extension: `.png`, `.jpg`, `.jpeg`, `.webp`.",
+            action_name
+        )),
+    }
 }
 
 fn validate_child_input_url(url: &str, action_name: &str, input_index: usize) -> Result<(), String> {

--- a/templates/src/providers/mod.rs
+++ b/templates/src/providers/mod.rs
@@ -12,7 +12,9 @@ pub(crate) use error::{
     ProviderError, ProviderKind,
 };
 pub(crate) use ollama::send_request as send_ollama_request;
-pub(crate) use openai::send_request as send_openai_request;
+pub(crate) use openai::{
+    send_image_request as send_openai_image_request, send_request as send_openai_request,
+};
 pub(crate) use runtime::{
     resolve_inputs as resolve_provider_inputs, Cargo as AgentCargo, ValidatedResponse,
 };

--- a/templates/src/providers/openai.rs
+++ b/templates/src/providers/openai.rs
@@ -1,4 +1,5 @@
 // External Crates
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use super::{runtime::ContentPart, ProviderError, ProviderKind};
 use reqwest::ClientBuilder;
 use serde::{Deserialize, Serialize};
@@ -37,6 +38,24 @@ pub struct ImageUrl {
 pub struct FileInput {
     pub filename: String,
     pub file_data: String,
+}
+
+#[derive(Serialize, Debug)]
+struct ImageGenerationRequest {
+    model: String,
+    prompt: String,
+    n: u8,
+    output_format: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct ImageGenerationResponse {
+    data: Vec<ImageGenerationData>,
+}
+
+#[derive(Deserialize, Debug)]
+struct ImageGenerationData {
+    b64_json: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -81,6 +100,19 @@ fn normalize_chatgpt_responses_url(url: &str) -> String {
         trimmed.to_string()
     } else {
         format!("{trimmed}/responses")
+    }
+}
+
+fn normalize_openai_images_url(url: &str) -> Result<String, ProviderError> {
+    let trimmed = url.trim_end_matches('/');
+    if let Some(index) = trimmed.find("/v1/") {
+        return Ok(format!("{}/v1/images/generations", &trimmed[..index]));
+    }
+
+    if trimmed.ends_with("/v1") {
+        Ok(format!("{trimmed}/images/generations"))
+    } else {
+        Ok(format!("{trimmed}/v1/images/generations"))
     }
 }
 
@@ -148,6 +180,30 @@ fn parse_stream_failure_message(payload: &serde_json::Value) -> Option<String> {
                 .and_then(serde_json::Value::as_str)
                 .map(str::to_string)
         })
+}
+
+fn find_image_generation_result(payload: &serde_json::Value) -> Option<&str> {
+    match payload {
+        serde_json::Value::Object(map) => {
+            let is_image_generation_call =
+                map.get("type").and_then(serde_json::Value::as_str)
+                    == Some("image_generation_call");
+            if is_image_generation_call {
+                if let Some(result) = map
+                    .get("result")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                {
+                    return Some(result);
+                }
+            }
+
+            map.values().find_map(find_image_generation_result)
+        }
+        serde_json::Value::Array(items) => items.iter().find_map(find_image_generation_result),
+        _ => None,
+    }
 }
 
 async fn send_chat_completions_request(
@@ -350,6 +406,120 @@ async fn send_chatgpt_codex_responses_request(
     ))
 }
 
+async fn send_chatgpt_codex_image_request(
+    url: &String,
+    model: &String,
+    prompt: &str,
+    timeout_in_sec: u64,
+    token: &String,
+    output_format: &str,
+) -> Result<Vec<u8>, ProviderError> {
+    let client = ClientBuilder::new()
+        .timeout(Duration::from_secs(timeout_in_sec))
+        .build()
+        .map_err(|error| ProviderError::from_reqwest(ProviderKind::OpenAi, error))?;
+
+    let request_payload = serde_json::json!({
+        "model": model,
+        "instructions": "Generate the requested image and return it using the image_generation tool.",
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": prompt
+                    }
+                ]
+            }
+        ],
+        "tools": [
+            {
+                "type": "image_generation",
+                "output_format": output_format
+            }
+        ],
+        "store": false,
+        "stream": true
+    });
+
+    let endpoint = normalize_chatgpt_responses_url(url);
+    let http_resp = client
+        .post(endpoint.as_str())
+        .header("Authorization", format!("Bearer {}", token))
+        .header("Content-Type", "application/json")
+        .json(&request_payload)
+        .send()
+        .await
+        .map_err(|error| ProviderError::from_reqwest(ProviderKind::OpenAi, error))?;
+
+    let status = http_resp.status();
+    let raw_stream = http_resp
+        .text()
+        .await
+        .map_err(|error| ProviderError::from_reqwest(ProviderKind::OpenAi, error))?;
+
+    if !status.is_success() {
+        return Err(ProviderError::from_http_status(
+            ProviderKind::OpenAi,
+            status,
+            raw_stream.as_str(),
+        ));
+    }
+
+    let mut encoded_image: Option<String> = None;
+
+    for raw_line in raw_stream.lines() {
+        let line = raw_line.trim_end_matches('\r');
+        let Some(payload) = line.strip_prefix("data: ") else {
+            continue;
+        };
+        if payload.trim().is_empty() || payload.trim() == "[DONE]" {
+            continue;
+        }
+
+        let event_json = serde_json::from_str::<serde_json::Value>(payload).map_err(|error| {
+            ProviderError::invalid_response(
+                ProviderKind::OpenAi,
+                format!("Failed to parse streaming payload: {error}\nPayload: {payload}"),
+            )
+        })?;
+
+        if let Some(result) = find_image_generation_result(&event_json) {
+            encoded_image = Some(result.to_string());
+            continue;
+        }
+
+        let event_type = event_json
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("");
+
+        if event_type == "response.failed" || event_type == "error" {
+            let detail =
+                parse_stream_failure_message(&event_json).unwrap_or_else(|| payload.to_string());
+            return Err(ProviderError::invalid_response(
+                ProviderKind::OpenAi,
+                format!("OpenAI stream failed: {detail}"),
+            ));
+        }
+    }
+
+    let encoded_image = encoded_image.ok_or_else(|| {
+        ProviderError::invalid_response(
+            ProviderKind::OpenAi,
+            "Image generation stream did not include an `image_generation_call` result payload.",
+        )
+    })?;
+
+    BASE64_STANDARD.decode(encoded_image).map_err(|error| {
+        ProviderError::invalid_response(
+            ProviderKind::OpenAi,
+            format!("Failed to decode generated image bytes: {error}"),
+        )
+    })
+}
+
 pub async fn send_request(
     url: &String,
     model: &String,
@@ -379,6 +549,91 @@ pub async fn send_request(
         )
         .await
     }
+}
+
+pub async fn send_image_request(
+    url: &String,
+    model: &String,
+    prompt: &str,
+    timeout_in_sec: u64,
+    token: &String,
+    output_format: &str,
+) -> Result<Vec<u8>, ProviderError> {
+    if is_chatgpt_codex_responses_endpoint(url) {
+        return send_chatgpt_codex_image_request(
+            url,
+            model,
+            prompt,
+            timeout_in_sec,
+            token,
+            output_format,
+        )
+        .await;
+    }
+
+    let endpoint = normalize_openai_images_url(url)?;
+    let client = ClientBuilder::new()
+        .timeout(Duration::from_secs(timeout_in_sec))
+        .build()
+        .map_err(|error| ProviderError::from_reqwest(ProviderKind::OpenAi, error))?;
+
+    let request = ImageGenerationRequest {
+        model: model.clone(),
+        prompt: prompt.to_string(),
+        n: 1,
+        output_format: output_format.to_string(),
+    };
+
+    let http_resp = client
+        .post(endpoint.as_str())
+        .header("Authorization", format!("Bearer {}", token))
+        .header("Content-Type", "application/json")
+        .json(&request)
+        .send()
+        .await
+        .map_err(|error| ProviderError::from_reqwest(ProviderKind::OpenAi, error))?;
+
+    let status = http_resp.status();
+    let body_bytes = http_resp
+        .bytes()
+        .await
+        .map_err(|error| ProviderError::from_reqwest(ProviderKind::OpenAi, error))?;
+
+    if !status.is_success() {
+        let raw = String::from_utf8_lossy(&body_bytes);
+        return Err(ProviderError::from_http_status(
+            ProviderKind::OpenAi,
+            status,
+            &raw,
+        ));
+    }
+
+    let response: ImageGenerationResponse = serde_json::from_slice(&body_bytes).map_err(|error| {
+        let raw = String::from_utf8_lossy(&body_bytes);
+        ProviderError::invalid_response(
+            ProviderKind::OpenAi,
+            format!("Failed to parse image-generation JSON: {error}\nRaw response:\n{raw}"),
+        )
+    })?;
+
+    let encoded_image = response
+        .data
+        .first()
+        .map(|image| image.b64_json.trim())
+        .filter(|image| !image.is_empty())
+        .ok_or_else(|| {
+            ProviderError::invalid_response(
+                ProviderKind::OpenAi,
+                "Image generation response did not include `data[0].b64_json`.",
+            )
+        })?;
+
+    BASE64_STANDARD.decode(encoded_image).map_err(|error| {
+        ProviderError::invalid_response(
+            ProviderKind::OpenAi,
+            format!("Failed to decode generated image bytes: {error}"),
+        )
+    })
 }
 
 fn chat_request_content_parts(content_parts: &[ContentPart]) -> Vec<ChatRequestContentPart> {

--- a/tests/build_support_schema.rs
+++ b/tests/build_support_schema.rs
@@ -216,7 +216,7 @@ fn rejects_unsupported_action_kind_with_actionable_path() {
         .to_string();
 
     assert!(err.contains("$.actions[0].run[0].kind"));
-    assert!(err.contains("supported: `exec`, `email_me`, `agent`"));
+    assert!(err.contains("supported: `exec`, `email_me`, `agent`, `generate_image`"));
 }
 
 #[test]
@@ -268,6 +268,95 @@ fn accepts_email_me_string_and_variable_parts() {
     assert!(generated.contains("kind: \"email_me\".to_string()"));
     assert!(generated.contains("subject: Some(vec![RunArg::Literal(\"Weather alert for \".to_string()), RunArg::Variable(\"city\".to_string())])"));
     assert!(generated.contains("text: Some(vec![RunArg::Literal(\"Bring an umbrella because raining=\".to_string()), RunArg::Variable(\"raining\".to_string())])"));
+}
+
+#[test]
+fn accepts_generate_image_step_with_prompt_and_path_parts() {
+    let cfg = config_with(
+        r#""product_name": { "type": "string" }, "product_slug": { "type": "string" }"#,
+        r#"[
+          {
+            "name": "generate_image",
+            "logic": { "==": [ { "var": "product_name" }, "Widget" ] },
+            "run": [
+              {
+                "kind": "generate_image",
+                "model": "gpt-image-1",
+                "prompt": ["Create a render for ", { "var": "product_name" }],
+                "path": ["./artifacts/", { "var": "product_slug" }, ".png"]
+              }
+            ]
+          }
+        ]"#,
+    );
+
+    let generated = build_support::generate_agent_model_from_str(&cfg).unwrap();
+
+    assert!(generated.contains("kind: \"generate_image\".to_string()"));
+    assert!(generated.contains("model: Some(\"gpt-image-1\".to_string())"));
+    assert!(generated.contains(
+        "prompt: Some(vec![RunArg::Literal(\"Create a render for \".to_string()), RunArg::Variable(\"product_name\".to_string())])"
+    ));
+    assert!(generated.contains(
+        "path: Some(vec![RunArg::Literal(\"./artifacts/\".to_string()), RunArg::Variable(\"product_slug\".to_string()), RunArg::Literal(\".png\".to_string())])"
+    ));
+}
+
+#[test]
+fn rejects_generate_image_output_variable() {
+    let cfg = config_with(
+        r#""product_name": { "type": "string" }"#,
+        r#"[
+          {
+            "name": "generate_image",
+            "logic": { "==": [ { "var": "product_name" }, "Widget" ] },
+            "run": [
+              {
+                "kind": "generate_image",
+                "model": "gpt-image-1",
+                "prompt": "Create a render",
+                "path": "./artifacts/widget.png",
+                "output_variable": "image_path"
+              }
+            ]
+          }
+        ]"#,
+    );
+
+    let err = build_support::generate_agent_model_from_str(&cfg)
+        .unwrap_err()
+        .to_string();
+
+    assert!(err.contains("$.actions[0].run[0].output_variable"));
+    assert!(err.contains("not supported for `generate_image`"));
+}
+
+#[test]
+fn rejects_generate_image_unsupported_output_extension() {
+    let cfg = config_with(
+        r#""product_name": { "type": "string" }"#,
+        r#"[
+          {
+            "name": "generate_image",
+            "logic": { "==": [ { "var": "product_name" }, "Widget" ] },
+            "run": [
+              {
+                "kind": "generate_image",
+                "model": "gpt-image-1",
+                "prompt": "Create a render",
+                "path": "./artifacts/widget.gif"
+              }
+            ]
+          }
+        ]"#,
+    );
+
+    let err = build_support::generate_agent_model_from_str(&cfg)
+        .unwrap_err()
+        .to_string();
+
+    assert!(err.contains("$.actions[0].run[0].path"));
+    assert!(err.contains("supported extension"));
 }
 
 #[test]


### PR DESCRIPTION
- add parser, codegen, and runtime support for `generate_image` with explicit `model`, `prompt`, and `path`
- support direct OpenAI Images API transport and add Responses-style account-transport handling where the backend supports it
- document transport-specific model guidance and cover schema, runtime, and provider tests for the new run kind

Related to: CAI-2054