### PR TITLE
feat(runtime): add structural action-only execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ cargo ai account agents hatch adder_test
 
 Cargo AI keeps the authoring model intentionally small:
 
-1. `inputs`
+1. optional `inputs`
    Ordered model-facing input such as `text`, `url`, or `image`.
 2. optional `runtime_vars`
    Typed caller-supplied values that can control action logic, `when`, and selected run-step fields at invocation time.
@@ -203,7 +203,7 @@ cargo ai hatch my_agent --config ./my_agent.json
 
 For Windows users, run `my_agent.exe` or just `my_agent`.
 
-You can also override or inject runtime input without editing the JSON. Generated agents accept flags such as `--input-text`, `--input-url`, and `--input-file`. By default, runtime input flags replace the baked `inputs` array for that run. Use `--input-mode append` to keep baked inputs first, or `--input-mode prepend` to place runtime inputs before the baked inputs.
+You can also override or inject runtime input without editing the JSON. Generated agents accept flags such as `--input-text`, `--input-url`, and `--input-file`. By default, runtime input flags replace the baked `inputs` array for that run. Use `--input-mode append` to keep baked inputs first, or `--input-mode prepend` to place runtime inputs before the baked inputs. If `agent_schema.properties` is empty, those model-facing runtime input flags are invalid because Cargo AI skips the initial model call in that structural action-only shape.
 
 ```bash
 ./my_agent --input-text "What is 3 + 3?"
@@ -227,6 +227,36 @@ You can also declare typed runtime variables for action control and step-local s
 ```
 
 Quote `--run-var` values when your shell would otherwise split them, for example `--run-var subject="Quarterly Review"`.
+
+You can also author a structural action-only worker by leaving `agent_schema.properties` empty and omitting top-level `inputs`. In that shape, Cargo AI skips the initial model pass and starts directly at action `logic`, which can read declared `runtime.*` values.
+
+```json
+{
+  "version": "2026-03-03.r1",
+  "runtime_vars": {
+    "generate_images": { "type": "boolean", "default": true },
+    "hero_image_model": { "type": "string" }
+  },
+  "agent_schema": {
+    "type": "object",
+    "properties": {}
+  },
+  "actions": [
+    {
+      "name": "generate_launch_assets",
+      "logic": { "==": [{ "var": "runtime.generate_images" }, true] },
+      "run": [
+        {
+          "kind": "generate_image",
+          "model": { "var": "runtime.hero_image_model" },
+          "prompt": "Create the launch image.",
+          "path": "./artifacts/launch.png"
+        }
+      ]
+    }
+  ]
+}
+```
 
 ## Start Simple, Then Expand
 

--- a/src/commands/preflight.rs
+++ b/src/commands/preflight.rs
@@ -238,6 +238,26 @@ fn resolved_inputs_for_run(sub_m: &ArgMatches) -> Result<Vec<crate::Input>, Stri
     })
 }
 
+fn validate_structural_action_only_inputs(
+    has_output_schema_properties: bool,
+    selected_inputs: &[crate::Input],
+) -> Result<(), String> {
+    if has_output_schema_properties || selected_inputs.is_empty() {
+        return Ok(());
+    }
+
+    Err(
+        "This agent declares empty `agent_schema.properties`; runtime model-facing input flags such as --input-text, --input-url, --input-image, and --input-file are not allowed because there is no model pass to consume them."
+            .to_string(),
+    )
+}
+
+fn empty_action_only_output() -> Result<crate::Output, String> {
+    serde_json::from_value(serde_json::json!({})).map_err(|error| {
+        format!("Internal error: failed to initialize action-only output placeholder: {error}")
+    })
+}
+
 fn resolved_runtime_vars_for_run(
     sub_m: &ArgMatches,
 ) -> Result<serde_json::Map<String, serde_json::Value>, String> {
@@ -558,15 +578,6 @@ pub async fn run(sub_m: &ArgMatches) -> bool {
         }
     }
 
-    if let Err(validation_issues) = validate_provider_request(provider, &model, &url, &token) {
-        for issue in validation_issues {
-            eprintln!("{issue}");
-        }
-        return false;
-    }
-
-    // End: Argument assignments
-
     let selected_inputs = match resolved_inputs_for_run(sub_m) {
         Ok(selected_inputs) => selected_inputs,
         Err(error) => {
@@ -581,6 +592,58 @@ pub async fn run(sub_m: &ArgMatches) -> bool {
             return false;
         }
     };
+    let has_output_schema_properties = crate::has_output_schema_properties();
+
+    if let Err(error) =
+        validate_structural_action_only_inputs(has_output_schema_properties, &selected_inputs)
+    {
+        eprintln!("❌ {error}");
+        return false;
+    }
+
+    if !has_output_schema_properties {
+        let output = match empty_action_only_output() {
+            Ok(output) => output,
+            Err(error) => {
+                eprintln!("❌ {error}");
+                return false;
+            }
+        };
+        let actions = crate::actions();
+        let action_provider_context = super::preflight_actions::ActionProviderContext {
+            provider,
+            url: url.clone(),
+            token: token.clone(),
+            inference_timeout_in_sec,
+        };
+
+        return match super::preflight_actions::apply_actions(
+            &output,
+            &actions,
+            &runtime_vars,
+            &action_provider_context,
+            max_agent_depth,
+            runtime_budget,
+        )
+        .await
+        {
+            Ok(()) => true,
+            Err(error) => {
+                eprintln!("❌ {error}");
+                false
+            }
+        };
+    }
+
+    if let Err(validation_issues) = validate_provider_request(provider, &model, &url, &token) {
+        for issue in validation_issues {
+            eprintln!("{issue}");
+        }
+        return false;
+    }
+
+    // End: Argument assignments
+
     let resolved_inputs = match crate::providers::resolve_provider_inputs(&selected_inputs).await {
         Ok(resolved_inputs) => resolved_inputs,
         Err(error) => {
@@ -765,7 +828,7 @@ pub async fn run(sub_m: &ArgMatches) -> bool {
 mod tests {
     use super::{
         cli_override_descriptions, profile_selection_messages, resolve_runtime_vars_from_specs,
-        unknown_server_messages, LoadedProfileKind,
+        unknown_server_messages, validate_structural_action_only_inputs, LoadedProfileKind,
     };
     use crate::args::test_cli_command;
     use serde_json::json;
@@ -1227,6 +1290,42 @@ mod tests {
         .expect_err("empty integers should fail");
 
         assert!(error.contains("cannot be empty"));
+    }
+
+    #[test]
+    fn validate_structural_action_only_inputs_allows_empty_input_set() {
+        let selected_inputs = Vec::new();
+
+        let result = validate_structural_action_only_inputs(false, &selected_inputs);
+
+        assert!(result.is_ok(), "empty input set should be allowed");
+    }
+
+    #[test]
+    fn validate_structural_action_only_inputs_rejects_runtime_inputs() {
+        let selected_inputs = vec![crate::Input::Text {
+            text: "hello".to_string(),
+        }];
+
+        let error = validate_structural_action_only_inputs(false, &selected_inputs)
+            .expect_err("runtime inputs should be rejected");
+
+        assert!(error.contains("empty `agent_schema.properties`"));
+        assert!(error.contains("--input-text"));
+    }
+
+    #[test]
+    fn validate_structural_action_only_inputs_allows_schema_backed_agents() {
+        let selected_inputs = vec![crate::Input::Text {
+            text: "hello".to_string(),
+        }];
+
+        let result = validate_structural_action_only_inputs(true, &selected_inputs);
+
+        assert!(
+            result.is_ok(),
+            "schema-backed agents should keep accepting inputs"
+        );
     }
 
     #[tokio::test]

--- a/templates/build_support.rs
+++ b/templates/build_support.rs
@@ -408,7 +408,6 @@ fn parse_agent_config(root: &Value) -> Result<AgentConfig, BuildError> {
     let schema_version = get_required_string(root_obj, "version", "$")?;
     validate_schema_version(schema_version, "$.version")?;
 
-    let inputs = parse_inputs(root_obj)?;
     let runtime_vars = parse_runtime_vars(root_obj)?;
 
     let schema = get_required_object(root_obj, "agent_schema", "$")?;
@@ -433,6 +432,14 @@ fn parse_agent_config(root: &Value) -> Result<AgentConfig, BuildError> {
         parsed_properties.push(parsed_property);
     }
 
+    if parsed_properties.is_empty() && root_obj.contains_key("inputs") {
+        return Err(BuildError::config(
+            "$.inputs",
+            "top-level `inputs` are not allowed when `agent_schema.properties` is empty; remove `inputs` or declare at least one schema property",
+        ));
+    }
+
+    let inputs = parse_inputs(root_obj)?;
     let action_field_types = action_field_types(&schema_field_types, &runtime_vars);
     let actions = parse_actions(root_obj, &schema_field_types, &action_field_types)?;
 
@@ -522,14 +529,12 @@ fn is_leap_year(year: u32) -> bool {
 }
 
 fn parse_inputs(root_obj: &Map<String, Value>) -> Result<Vec<InputSpec>, BuildError> {
-    let inputs = get_required_array(root_obj, "inputs", "$")?;
-    if inputs.is_empty() {
-        return Err(BuildError::config(
-            "$.inputs",
-            "must contain at least one entry",
-        ));
-    }
-
+    let Some(inputs_value) = root_obj.get("inputs") else {
+        return Ok(Vec::new());
+    };
+    let inputs = inputs_value
+        .as_array()
+        .ok_or_else(|| BuildError::config("$.inputs", "expected an array"))?;
     parse_input_specs(inputs, "$.inputs")
 }
 
@@ -2938,6 +2943,7 @@ fn render_agent_model(config: &AgentConfig) -> String {
         })
         .collect::<Vec<_>>()
         .join("");
+    let has_output_schema_properties = !config.properties.is_empty();
 
     format!(
         r##"
@@ -2966,6 +2972,10 @@ pub enum Input {{
 
 pub fn inputs() -> Vec<Input> {{
     vec![{input_list}]
+}}
+
+pub fn has_output_schema_properties() -> bool {{
+    {has_output_schema_properties}
 }}
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]

--- a/templates/guidance/action-rules.md
+++ b/templates/guidance/action-rules.md
@@ -10,7 +10,7 @@ For broader shape and validation rules, also read:
 ## Top-Level Shape
 - Required top-level keys:
   - `version`
-  - `inputs`
+  - optional `inputs`
   - optional `runtime_vars`
   - `agent_schema`
   - `actions`
@@ -68,6 +68,8 @@ These documented step kinds and helper fields are exhaustive for the current MVP
 - Top-level `agent_schema` fields are the returned output of the agent.
 - Action steps are side effects or follow-up orchestration after that output exists.
 - `output_variable` captures step-local stdout only. It does not change the returned top-level output object.
+- If `agent_schema.properties` is empty, Cargo AI skips the initial model call and starts directly at the action layer.
+- In that structural action-only shape, top-level `inputs` and runtime `--input-*` flags are invalid.
 
 ## Variable Namespace Rules
 - Captured names are flat. Dotted names are invalid.
@@ -81,6 +83,7 @@ These documented step kinds and helper fields are exhaustive for the current MVP
 - Top-level action `logic` can read:
   - top-level model output fields
   - declared `runtime.*` values
+  - for the structural action-only shape, only declared `runtime.*` values are available at action start
 - `when` and string-part substitutions can read:
   - top-level model output fields
   - declared `runtime.*` values

--- a/templates/guidance/agent-definition-contract.md
+++ b/templates/guidance/agent-definition-contract.md
@@ -10,7 +10,7 @@ Unless a section says otherwise, the supported field lists below are exhaustive 
 Every agent definition must be a JSON object with these keys in this order:
 
 1. `version`
-2. `inputs`
+2. optional `inputs`
 3. optional `runtime_vars`
 4. `agent_schema`
 5. `actions`
@@ -24,8 +24,8 @@ Every agent definition must be a JSON object with these keys in this order:
 
 ## `inputs`
 
-- Required.
-- Array with at least one item.
+- Optional.
+- If present, must be an array with at least one item.
 - Supported input shapes:
   - `text`
     - required: `type`, `text`
@@ -68,6 +68,7 @@ Authoring guidance:
 - Use runtime flags when the caller should choose the content at invocation time.
 - If you use `--input-file` and still need a text instruction, either also pass `--input-text` in replace mode or choose `--input-mode append` / `--input-mode prepend` so the baked text instruction is still included.
 - `{"type":"file","path":"..."}` is for a definition-owned fixed file path, not for a caller-selected runtime file.
+- If `agent_schema.properties` is empty, runtime `--input-*` flags are invalid because Cargo AI skips the model call in that structural action-only shape.
 
 ## `runtime_vars`
 
@@ -116,6 +117,7 @@ Example:
   - `properties: { ... }`
 - Each property must define a `type`.
 - Top-level property names are reserved for action-variable lookup. Step-captured variable names cannot reuse them.
+- `properties` may be empty. That declares the structural action-only shape.
 
 Supported top-level property `type` values:
 - `string`
@@ -139,6 +141,14 @@ Unsupported schema shapes for the current MVP:
 - nested objects
 - union types
 
+Structural action-only rule:
+- If `agent_schema.properties` is empty, Cargo AI skips the initial model call and begins at the action layer.
+- In that shape, baked top-level `inputs` must be absent.
+- In that shape, runtime model-facing `--input-*` flags are invalid.
+- Top-level action `logic` starts with declared `runtime.*` values only.
+- Step `when` and substitution surfaces may use declared `runtime.*` values plus prior captured step variables as the action runs.
+- References to top-level model-output fields are invalid in that shape because no initial model output exists.
+
 ## `actions`
 
 - Required.
@@ -149,8 +159,8 @@ Unsupported schema shapes for the current MVP:
   - `run`
 
 `logic` uses JSON Logic against the top-level action data object. At action start, that means:
-- top-level model output fields
-- declared `runtime.*` values
+- top-level model output fields plus declared `runtime.*` values for schema-backed agents
+- declared `runtime.*` values only for the structural action-only shape
 
 If `logic` evaluates true, the action's `run` steps execute in order.
 

--- a/templates/src/main.rs
+++ b/templates/src/main.rs
@@ -865,6 +865,26 @@ fn resolved_inputs_for_run(cmd_args: &clap::ArgMatches) -> Result<Vec<Input>, St
     })
 }
 
+fn validate_structural_action_only_inputs(
+    has_output_schema_properties: bool,
+    selected_inputs: &[Input],
+) -> Result<(), String> {
+    if has_output_schema_properties || selected_inputs.is_empty() {
+        return Ok(());
+    }
+
+    Err(
+        "This agent declares empty `agent_schema.properties`; runtime model-facing input flags such as --input-text, --input-url, --input-image, and --input-file are not allowed because there is no model pass to consume them."
+            .to_string(),
+    )
+}
+
+fn empty_action_only_output() -> Result<Output, String> {
+    serde_json::from_value(serde_json::json!({})).map_err(|error| {
+        format!("Internal error: failed to initialize action-only output placeholder: {error}")
+    })
+}
+
 fn resolved_runtime_vars_for_run(
     cmd_args: &clap::ArgMatches,
 ) -> Result<serde_json::Map<String, serde_json::Value>, String> {
@@ -1121,13 +1141,6 @@ async fn main() {
         }
     }
 
-    if let Err(validation_issues) = validate_provider_request(provider, &model, &url, &token) {
-        for issue in validation_issues {
-            eprintln!("{issue}");
-        }
-        return;
-    }
-
     let selected_inputs = match resolved_inputs_for_run(&cmd_args) {
         Ok(selected_inputs) => selected_inputs,
         Err(error) => {
@@ -1142,6 +1155,55 @@ async fn main() {
             return;
         }
     };
+    let has_output_schema_properties = has_output_schema_properties();
+
+    if let Err(error) =
+        validate_structural_action_only_inputs(has_output_schema_properties, &selected_inputs)
+    {
+        eprintln!("❌ {error}");
+        return;
+    }
+
+    if !has_output_schema_properties {
+        let output = match empty_action_only_output() {
+            Ok(output) => output,
+            Err(error) => {
+                eprintln!("❌ {error}");
+                return;
+            }
+        };
+        let actions = actions();
+        let action_provider_context = ActionProviderContext {
+            provider,
+            url: url.clone(),
+            token: token.clone(),
+            inference_timeout_in_sec,
+        };
+        if let Err(error) =
+            apply_actions(
+                &output,
+                &actions,
+                &runtime_vars,
+                config.as_ref(),
+                &action_provider_context,
+                max_agent_depth,
+                runtime_budget,
+            )
+            .await
+        {
+            eprintln!("❌ {error}");
+            std::process::exit(1);
+        }
+        return;
+    }
+
+    if let Err(validation_issues) = validate_provider_request(provider, &model, &url, &token) {
+        for issue in validation_issues {
+            eprintln!("{issue}");
+        }
+        return;
+    }
+
     let resolved_inputs = match crate::providers::resolve_provider_inputs(&selected_inputs).await {
         Ok(resolved_inputs) => resolved_inputs,
         Err(error) => {

--- a/tests/build_support_schema.rs
+++ b/tests/build_support_schema.rs
@@ -13,6 +13,32 @@ fn config_with(properties: &str, actions: &str) -> String {
 }
 
 fn config_with_runtime_vars(properties: &str, runtime_vars: &str, actions: &str) -> String {
+    config_with_optional_inputs(
+        properties,
+        runtime_vars,
+        actions,
+        Some(
+            r#"[
+        { "type": "text", "text": "Test prompt" }
+    ]"#,
+        ),
+    )
+}
+
+fn config_with_optional_inputs(
+    properties: &str,
+    runtime_vars: &str,
+    actions: &str,
+    inputs: Option<&str>,
+) -> String {
+    let inputs_block = if let Some(inputs) = inputs {
+        format!(
+            r#",
+    "inputs": {inputs}"#
+        )
+    } else {
+        String::new()
+    };
     let runtime_vars_block = if runtime_vars.trim().is_empty() {
         String::new()
     } else {
@@ -26,10 +52,7 @@ fn config_with_runtime_vars(properties: &str, runtime_vars: &str, actions: &str)
 
     format!(
         r#"{{
-    "version": "2026-03-03.r1",
-    "inputs": [
-        {{ "type": "text", "text": "Test prompt" }}
-    ],
+    "version": "2026-03-03.r1"{inputs_block},
     "agent_schema": {{
         "type": "object",
         "properties": {{
@@ -39,6 +62,52 @@ fn config_with_runtime_vars(properties: &str, runtime_vars: &str, actions: &str)
     "actions": {actions}
 }}"#
     )
+}
+
+#[test]
+fn accepts_schema_backed_agents_without_baked_inputs() {
+    let cfg = config_with_optional_inputs(r#""answer": { "type": "integer" }"#, "", "[]", None);
+
+    let generated = build_support::generate_agent_model_from_str(&cfg).unwrap();
+
+    assert!(generated.contains("pub fn inputs() -> Vec<Input> {\n    vec![]\n}"));
+    assert!(generated.contains("pub fn has_output_schema_properties() -> bool {\n    true\n}"));
+}
+
+#[test]
+fn accepts_structural_action_only_agents_without_inputs() {
+    let cfg = config_with_optional_inputs(
+        "",
+        r#""generate_images": { "type": "boolean", "default": true }"#,
+        "[]",
+        None,
+    );
+
+    let generated = build_support::generate_agent_model_from_str(&cfg).unwrap();
+
+    assert!(generated.contains("pub fn inputs() -> Vec<Input> {\n    vec![]\n}"));
+    assert!(generated.contains("pub fn has_output_schema_properties() -> bool {\n    false\n}"));
+}
+
+#[test]
+fn rejects_baked_inputs_when_schema_properties_are_empty() {
+    let cfg = config_with_optional_inputs(
+        "",
+        "",
+        "[]",
+        Some(
+            r#"[
+        { "type": "text", "text": "Test prompt" }
+    ]"#,
+        ),
+    );
+
+    let err = build_support::generate_agent_model_from_str(&cfg)
+        .unwrap_err()
+        .to_string();
+
+    assert!(err.contains("$.inputs"));
+    assert!(err.contains("are not allowed when `agent_schema.properties` is empty"));
 }
 
 #[test]


### PR DESCRIPTION
- allow top-level baked inputs to be omitted and reject them when agent_schema.properties is empty
- skip the initial model pass for empty-schema agents with no runtime inputs and reject runtime --input-* flags in that branch
- update offline authoring docs and add parser/runtime coverage for structural action-only workers

Related to: CAI-2066