### PR TITLE
fix(hatch): restore template runtime parity and update checkout

### DIFF
--- a/.github/workflows/multi-os-ci.yml
+++ b/.github/workflows/multi-os-ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4 
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/windows-runtime-artifact.yml
+++ b/.github/workflows/windows-runtime-artifact.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/templates/src/main.rs
+++ b/templates/src/main.rs
@@ -2265,6 +2265,21 @@ async fn main() {
     };
     let effective_action_execution = effective_action_execution_for_run(action_execution_override);
     let has_output_schema_properties = has_output_schema_properties();
+    let action_provider_context = ActionProviderContext {
+        provider,
+        profile_name: selected_profile.as_ref().map(|profile| profile.name.clone()),
+        auth_mode: resolved_invocation_auth_mode(
+            provider,
+            selected_profile.as_ref(),
+            has_explicit_token_override,
+            use_openai_account_transport,
+        )
+        .to_string(),
+        model: model.clone(),
+        url: url.clone(),
+        token: token.clone(),
+        inference_timeout_in_sec,
+    };
 
     if let Err(error) =
         validate_structural_action_only_inputs(
@@ -2286,21 +2301,6 @@ async fn main() {
             }
         };
         let actions = actions();
-        let action_provider_context = ActionProviderContext {
-            provider,
-            profile_name: selected_profile.as_ref().map(|profile| profile.name.clone()),
-            auth_mode: resolved_invocation_auth_mode(
-                provider,
-                selected_profile.as_ref(),
-                has_explicit_token_override,
-                use_openai_account_transport,
-            )
-            .to_string(),
-            model: model.clone(),
-            url: url.clone(),
-            token: token.clone(),
-            inference_timeout_in_sec,
-        };
         let action_output = ActionOutput::new(
             effective_action_execution,
             requested_render_mode,
@@ -2364,22 +2364,6 @@ async fn main() {
         }
         std::process::exit(1);
     }
-
-    let action_provider_context = ActionProviderContext {
-        provider,
-        profile_name: selected_profile.as_ref().map(|profile| profile.name.clone()),
-        auth_mode: resolved_invocation_auth_mode(
-            provider,
-            selected_profile.as_ref(),
-            has_explicit_token_override,
-            use_openai_account_transport,
-        )
-        .to_string(),
-        model: model.clone(),
-        url: url.clone(),
-        token: token.clone(),
-        inference_timeout_in_sec,
-    };
     println!("{}", action_provider_context.using_line());
 
     let static_context =


### PR DESCRIPTION
- hoist ActionProviderContext creation in the generated runtime template so hatch/check no longer references it before declaration
- keep template action-output seeding aligned with the working source runtime flow
- update checkout to actions/checkout@v5 in CI workflows to remove the Node 20 deprecation warning under Node 24 forcing

Related to: CAI-2082