### PR TITLE
refactor(tools): make tools build project-local only

### DIFF
--- a/README.md
+++ b/README.md
@@ -995,6 +995,8 @@ cargo ai tools lint hello_tool
 cargo ai tools check hello_tool
 ```
 
+`cargo ai tools build <name>` is a project-local authoring/build step. It materializes the managed artifact inside the current project only. Reusable machine-scope installs are reserved for a later package-backed install flow rather than direct promotion from a local project tool.
+
 `cargo ai tools lint <name>` is the static source/scaffold check for project-local source-backed tools. It checks Cargo AI-managed metadata linkage plus scaffold/layout expectations without executing the tool's business logic. Machine-only or binary-only tools are currently out of scope for linting.
 
 The tool `describe` result schema must be a nullable string. A step that sets `output_variable` still requires the actual `invoke` response to contain a non-null string result. For UI or background-process tools, keep rendering/artifact creation testable without launching the UI when practical, expose a smoke-test control such as `open_window=false`, and declare UI/process behavior in the tool `resource_profile`.

--- a/src/args/tools.rs
+++ b/src/args/tools.rs
@@ -20,14 +20,6 @@ pub fn command() -> Command {
                         .help("Rust target triple to pass through to cargo build")
                         .value_name("TRIPLE")
                         .num_args(1),
-                )
-                .arg(
-                    Arg::new("scope")
-                        .long("scope")
-                        .help("Where to materialize the managed tool artifact")
-                        .value_name("SCOPE")
-                        .value_parser(["project", "machine"])
-                        .default_value("project"),
                 ),
         )
         .subcommand(
@@ -96,7 +88,7 @@ pub fn command() -> Command {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn build_supports_target_and_scope() {
+    fn build_supports_target() {
         let matches = super::command()
             .try_get_matches_from([
                 "tools",
@@ -104,8 +96,6 @@ mod tests {
                 "render_cover_image",
                 "--target",
                 "aarch64-apple-darwin",
-                "--scope",
-                "machine",
             ])
             .expect("tools build should parse");
 
@@ -119,10 +109,6 @@ mod tests {
         assert_eq!(
             build.get_one::<String>("target").map(String::as_str),
             Some("aarch64-apple-darwin")
-        );
-        assert_eq!(
-            build.get_one::<String>("scope").map(String::as_str),
-            Some("machine")
         );
     }
 

--- a/src/commands/tools.rs
+++ b/src/commands/tools.rs
@@ -996,23 +996,7 @@ fn run_build(sub_m: &ArgMatches) -> bool {
             return false;
         }
     };
-    let scope = match sub_m
-        .get_one::<String>("scope")
-        .map(String::as_str)
-        .unwrap_or("project")
-    {
-        "project" => ToolScope::Project,
-        "machine" => ToolScope::Machine,
-        other => {
-            eprintln!(
-                "x Unsupported tool scope '{}'. Use `project` or `machine`.",
-                other
-            );
-            return false;
-        }
-    };
-
-    match build_source_tool(name, &build_target, scope, &project_root) {
+    match build_source_tool(name, &build_target, ToolScope::Project, &project_root) {
         Ok(resolved) => {
             println!("✓ Tool built");
             println!("Tool:   {}", resolved.tool_id);
@@ -1202,7 +1186,7 @@ fn resolve_tool_from_scope_root(
     let artifact = manifest.artifacts.get(target_triple).ok_or_else(|| {
         let remediation = if scope == ToolScope::Project && manifest.source.is_some() {
             format!(
-                " Materialize it with `cargo ai tools build {tool_id} --scope project --target {target_triple}` or assemble the full project with `cargo ai build --target {target_triple}`."
+                " Materialize it with `cargo ai tools build {tool_id} --target {target_triple}` or assemble the full project with `cargo ai build --target {target_triple}`."
             )
         } else {
             String::new()
@@ -1801,9 +1785,7 @@ mod tests {
         )
         .expect_err("missing artifact should fail");
 
-        assert!(error.contains(
-            "cargo ai tools build hello_tool --scope project --target aarch64-apple-darwin"
-        ));
+        assert!(error.contains("cargo ai tools build hello_tool --target aarch64-apple-darwin"));
         assert!(error.contains("cargo ai build --target aarch64-apple-darwin"));
 
         let _ = fs::remove_dir_all(project_root);


### PR DESCRIPTION
- remove the public `--scope` flag from `cargo ai tools build`
- route the build command through project scope only while keeping internal scoped build helpers available for later package-backed machine installs
- update remediation text and README guidance to point future machine installs at the later package-provenant flow

Related to: CAI-2092