### PR TITLE
chore(release): prepare cargo-ai 0.3.0 draft

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cargo-ai"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-ai"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "Build lightweight AI agents with Cargo. Powered by Rust. Declared in JSON."

--- a/README.md
+++ b/README.md
@@ -1128,6 +1128,7 @@ When you want deeper details, use these files:
 
 - Versioning and releases:
   - [VERSIONING.md](./VERSIONING.md)
+  - [releases/0.3.0.md](./releases/0.3.0.md)
   - [releases/0.2.0.md](./releases/0.2.0.md)
 - Examples:
   - [adder_test.json](./adder_test.json)

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -31,18 +31,20 @@ Implementation details may change underneath those surfaces, but changes that ma
 
 `1.0.0` should mean Cargo AI is ready to stand behind a stable core public contract across the surfaces above. That does not mean the product stops evolving. It means compatibility changes become rarer, more deliberate, and more tightly managed.
 
-## Why The Next Release Is 0.2.0
+## Why This Release Is 0.3.0
 
-The next release is `0.2.0` because Cargo AI has evolved meaningfully since `0.1.0` in user-visible ways, including:
+The `0.3.0` release is a pre-`1.0.0` contract release because Cargo AI has evolved meaningfully since `0.2.0` in user-visible ways, including:
 
-- typed `runtime_vars` for invocation-scoped action and run-step control
-- structural action-only workers that can skip the initial model pass when the definition uses the empty-schema no-input shape
-- Ollama-compatible image generation for the existing `generate_image` run-step contract
-- additive parent/child workflow contract improvements such as named reusable inputs and child runtime-var forwarding
-- parallel top-level action execution as an explicit orchestration mode
-- related runtime and validator alignment that changes what valid authored agent definitions can do
+- direct interpreted execution with `cargo ai run`
+- inline and stdin definition sources for fast scripted authoring flows
+- explicit runtime output rendering controls
+- project-local tool authoring, linting, checking, and build materialization
+- project build and source-portable package assembly
+- account-backed project list, publish, pull, visibility, and archive workflows
+- structured tool parameter support for validated array and object values
+- install, Cargo AI Home, package, and release-facing documentation updates
 
-That is larger than a patch-level `0.1.1` release, but it is not yet a `1.0.0` stability promise.
+That is larger than a patch-level `0.2.1` release, but it is not yet a `1.0.0` stability promise.
 
 ## Upgrade Guidance
 

--- a/releases/0.3.0.md
+++ b/releases/0.3.0.md
@@ -1,0 +1,68 @@
+# cargo-ai 0.3.0
+
+## CLI And Runtime Behavior
+
+- Add direct interpreted execution with `cargo ai run` so local JSON definitions can be run without first hatching a native executable.
+- Support path/config, inline JSON, and stdin definition sources for direct runs, with matching source options for hatch workflows.
+- Add explicit runtime rendering controls with `--render-mode auto|live|append-only`.
+- Improve account-hosted definition run and hatch workflows so hosted definitions can participate in the same authoring loop as local definitions.
+
+## Agent JSON And Runtime Contract
+
+- Keep named top-level inputs as reusable bindings for targeted input overrides and child-agent forwarding.
+- Support validated `array` and `object` values in tool parameters where structured payloads are part of the tool contract.
+- Preserve nullable structured payload behavior where the schema allows it.
+- Align generated runtime templates with interpreted runtime behavior so direct-run and hatched agents stay consistent.
+
+## Project Tools, Build, And Package
+
+- Add project-local tool authoring, linting, checking, and build materialization workflows.
+- Add `cargo ai build` for assembling explicit project build roots from `.cargo-ai/project.toml`.
+- Add `cargo ai package` for creating source-portable Cargo AI project packages from the same build-profile inputs.
+- Clarify that `cargo ai tools build` is project-local in this release.
+
+## Account Project Workflows
+
+- Add account project list, publish, pull, visibility, and archive workflows.
+- Preserve pulled package origin metadata under `.cargo-ai/origin/cargo-ai-package.toml`.
+- Restore pulled packages as project-shaped folders that can be inspected, built, and run locally.
+- Report package, archive, and request sizes during package/publish preparation so large assets are easier to catch.
+
+## Install And Distribution
+
+- Keep the official install path Cargo-first through `cargo install cargo-ai --locked`.
+- Document Cargo AI Home so profiles, account state, cached definitions, and managed tool metadata are easier to reason about.
+- Keep the rolling Windows preview artifact separate from stable versioned releases.
+- Update the public versioning policy for the `0.3.0` pre-`1.0.0` contract release.
+
+## Fixes And Polish
+
+- Improve hatch/runtime parity for generated templates.
+- Clean up hatch startup notes and runtime output behavior.
+- Improve error messages around missing project tools, source-backed tool requirements, and pulled project recovery steps.
+- Refresh locked dependency state used by the release build.
+
+## Public Notes
+
+- Windows preview artifact is currently unsigned.
+- `cargo ai tools build` is project-local in this release.
+
+## Why This Is 0.3.0
+
+This release meaningfully expands the user-facing Cargo AI contract compared with `0.2.0`: users can run definitions directly, build and package project-shaped workspaces, use project-local tools, and publish or pull account projects. That is larger than a patch-level `0.2.1` release, but still stops short of a `1.0.0` stability promise.
+
+See [VERSIONING.md](../VERSIONING.md) for the public versioning policy.
+
+## Upgrade
+
+```bash
+cargo install cargo-ai --locked
+```
+
+To check whether a newer crates.io version is available:
+
+```bash
+cargo ai version --check
+```
+
+After a meaningful pre-`1.0.0` upgrade, re-hatch generated agents if their embedded version/provenance status reports `out_of_sync`.


### PR DESCRIPTION
- Bump package metadata and lockfile root entry to 0.3.0
- Add public 0.3.0 release notes with approved public notes
- Update versioning rationale and README release links

Related to: CAI-2080