### PR TITLE
feat(run): --emit-output flag prints validated JSON between sentinel markers

### DIFF
--- a/src/args/runtime_common.rs
+++ b/src/args/runtime_common.rs
@@ -142,10 +142,57 @@ pub(crate) fn runtime_command(name: &'static str, about: &'static str) -> Comman
                 .help("Skip upfront tool contract checks and fail only if a tool step is reached")
                 .action(ArgAction::SetTrue),
         )
+        .arg(
+            Arg::new("emit_output")
+                .long("emit-output")
+                .help(
+                    "Print the validated agent output as JSON between sentinel markers \
+                     so programmatic callers can parse it without scraping action progress lines",
+                )
+                .action(ArgAction::SetTrue),
+        )
 }
+
+/// Sentinel markers that bracket the JSON written by `--emit-output`.
+/// Stable identifiers (not free-text) so downstream tooling can grep
+/// them out of the surrounding progress trail. Kept in this module
+/// so flag plumbing and consumers share one source of truth.
+pub const EMIT_OUTPUT_BEGIN: &str = "---begin-cargo-ai-output---";
+pub const EMIT_OUTPUT_END: &str = "---end-cargo-ai-output---";
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn help_describes_emit_output_flag() {
+        let mut command = super::runtime_command("runtime-test", "Runtime test command");
+        let mut help = Vec::new();
+        command
+            .write_long_help(&mut help)
+            .expect("runtime help should render");
+        let help = String::from_utf8(help).expect("help should be utf8");
+
+        assert!(help.contains("--emit-output"));
+        assert!(help.contains("Print the validated agent output as JSON"));
+    }
+
+    #[test]
+    fn emit_output_flag_parses_as_boolean() {
+        let command = super::runtime_command("runtime-test", "Runtime test command");
+        let matches = command
+            .try_get_matches_from(["runtime-test", "--emit-output"])
+            .expect("--emit-output should parse cleanly");
+        assert!(matches.get_flag("emit_output"));
+    }
+
+    #[test]
+    fn emit_output_defaults_to_false() {
+        let command = super::runtime_command("runtime-test", "Runtime test command");
+        let matches = command
+            .try_get_matches_from(["runtime-test"])
+            .expect("runtime command should parse with no flags");
+        assert!(!matches.get_flag("emit_output"));
+    }
+
     #[test]
     fn help_describes_input_file_as_supported_file_path() {
         let mut command = super::runtime_command("runtime-test", "Runtime test command");

--- a/src/commands/runtime.rs
+++ b/src/commands/runtime.rs
@@ -676,6 +676,51 @@ fn empty_action_only_output() -> serde_json::Value {
     serde_json::json!({})
 }
 
+/// Print the validated agent output as a single line of JSON,
+/// wrapped between sentinel markers from `crate::args::runtime_common`
+/// so callers can extract it from the surrounding progress trail.
+/// Stays single-line on purpose: the markers + compact JSON form a
+/// three-line block that's trivial to grep, copy, or re-parse.
+fn print_emit_output(output: &serde_json::Value) {
+    let payload =
+        serde_json::to_string(output).unwrap_or_else(|_| "{}".to_string());
+    println!("{}", crate::args::runtime_common::EMIT_OUTPUT_BEGIN);
+    println!("{payload}");
+    println!("{}", crate::args::runtime_common::EMIT_OUTPUT_END);
+}
+
+#[cfg(test)]
+mod emit_output_tests {
+    use super::print_emit_output;
+
+    // Exercises the public surface — verifies the helper exists,
+    // accepts a serde_json::Value, and routes through the sentinel
+    // constants. We deliberately don't intercept stdout here (would
+    // require ungating io capture across cargo test) — what we care
+    // about is that the marker constants and the helper compile
+    // against each other and stay in sync.
+    #[test]
+    fn print_emit_output_compiles_and_uses_marker_constants() {
+        let value = serde_json::json!({ "ok": true });
+        // Calling it confirms the function returns () and doesn't
+        // panic for a typical payload; the actual stdout shape is
+        // covered by downstream consumers like
+        // agent-studio's integration tests.
+        print_emit_output(&value);
+
+        // Pin the marker shape so a rename forces a deliberate test
+        // update — downstream tooling greps these strings.
+        assert_eq!(
+            crate::args::runtime_common::EMIT_OUTPUT_BEGIN,
+            "---begin-cargo-ai-output---"
+        );
+        assert_eq!(
+            crate::args::runtime_common::EMIT_OUTPUT_END,
+            "---end-cargo-ai-output---"
+        );
+    }
+}
+
 fn resolved_runtime_vars_for_run(
     sub_m: &ArgMatches,
     runtime_var_specs: &[crate::RuntimeVarSpec],
@@ -1163,6 +1208,13 @@ pub(crate) async fn run_with_definition_in_context(
         println!("{}", action_provider_context.using_line());
         action_output.print_execution_header();
 
+        // Action-only agents have no LLM stage, so the "validated
+        // output" is the empty object {} — emit it anyway when the
+        // flag is set so callers always see one block per run.
+        if sub_m.get_flag("emit_output") {
+            print_emit_output(&output);
+        }
+
         return match super::runtime_actions::apply_actions_with_data(
             &output,
             &actions,
@@ -1420,6 +1472,15 @@ pub(crate) async fn run_with_definition_in_context(
             return false;
         }
     };
+
+    // When the caller asked for the validated output explicitly,
+    // print it to stdout between sentinel markers so a downstream
+    // process can extract the JSON without scraping action progress
+    // lines. Emitted before the action graph runs so the model's
+    // structured reply is observable even if a later action fails.
+    if sub_m.get_flag("emit_output") {
+        print_emit_output(&output);
+    }
 
     match super::runtime_actions::apply_actions_with_data(
         &output,


### PR DESCRIPTION
## Summary

Adds a `--emit-output` flag to `cargo ai run` (and the shared runtime command base used by `hatch run`) that prints the validated agent output as a single JSON line wrapped between two stable sentinel markers, so programmatic callers can extract the model's structured reply from cargo-ai's mixed stdout without scraping action progress lines.

## Motivation

Tooling that runs cargo-ai as a subprocess — CI jobs, control planes, anything piping `--stdin` in — currently has no first-class way to retrieve the validated agent output. The output exists internally (the runtime parses it and feeds it to `apply_actions_with_data`) but only reaches stdout when an action chooses to echo it. Agents without actions, or callers that just want the LLM reply, have to author placeholder echo actions or scrape `[Action N: name]` lines — which silently broke for me when an exec emit wrapped continuation lines differently from the first line.

With `--emit-output` the runtime prints:

```
---begin-cargo-ai-output---
{"answer":4}
---end-cargo-ai-output---
```

right after schema validation succeeds, before the action graph runs. The action-only path (empty `agent_schema.properties`) also emits — with `{}` — so callers always see one block per run.

## Design choices

- **Opt-in flag, default false.** No existing behavior changes.
- **Sentinel markers in module constants.** `crate::args::runtime_common::{EMIT_OUTPUT_BEGIN, EMIT_OUTPUT_END}` are public, so consumers and tests share one source of truth — a rename has to update both ends in lockstep.
- **Single-line compact JSON between the markers.** Cheap to grep / sed / parse without worrying about pretty-print indentation. The three-line block is a stable signature consumers can rely on.
- **Emit before actions run.** The model's structured reply is observable even if a later action fails.

## Test plan

- [x] `args::runtime_common::tests::help_describes_emit_output_flag` — pins the help text surface.
- [x] `args::runtime_common::tests::emit_output_flag_parses_as_boolean` — pins the boolean parse.
- [x] `args::runtime_common::tests::emit_output_defaults_to_false` — pins the default.
- [x] `commands::runtime::emit_output_tests::print_emit_output_compiles_and_uses_marker_constants` — exercises the helper and pins the marker strings.
- [x] Full suite: `cargo test` — 441/441 pass on this branch.

Integration coverage (running an end-to-end agent with a real provider) is deliberately not added in this PR — that path requires mocking provider credentials and isn't where the change risk lives. Happy to add fixture-based coverage in a follow-up if you'd prefer.

## Use case

I'm building [Tembo Agent Studio](https://github.com/tembo/agent-studio), a self-hosted control plane that runs cargo-ai as a subprocess. Today it has to inject synthetic emit actions and parse the `[Action N: …]` wrapping to recover the model reply; this flag removes both stopgaps. Two follow-up PRs are planned: add an Anthropic provider, and surface token usage from provider responses.