### PR TITLE
feat(providers): surface OpenAI token usage from chat completions

### DIFF
--- a/src/commands/runtime.rs
+++ b/src/commands/runtime.rs
@@ -1258,6 +1258,10 @@ pub(crate) async fn run_with_definition_in_context(
     let content_parts = ai_cargo.content_parts();
 
     let mut response = String::new(); // Holds the LLM response
+    // Usage is provider-dependent. OpenAI populates it on the
+    // chat/completions path; other providers / endpoints leave it
+    // as None and we report tokens accordingly downstream.
+    let mut llm_usage: Option<crate::providers::LlmUsage> = None;
 
     if provider == ProviderKind::Ollama {
         let remaining =
@@ -1359,7 +1363,10 @@ pub(crate) async fn run_with_definition_in_context(
         )
         .await
         {
-            Ok(Ok(r)) => response.push_str(&r),
+            Ok(Ok(reply)) => {
+                response.push_str(&reply.text);
+                llm_usage = reply.usage;
+            }
             Ok(Err(error)) => {
                 let details = provider_error_messages(&error);
                 let summary = details
@@ -1397,6 +1404,19 @@ pub(crate) async fn run_with_definition_in_context(
                 return false;
             }
         };
+    }
+
+    // Surface token usage between the LLM call and the action graph
+    // so it lands in the run transcript next to "using: …" / "run:
+    // …" — useful for cost accounting, easy to grep, and ordered so
+    // a failed action graph still shows the cost of the model call.
+    if let Some(usage) = llm_usage {
+        println!(
+            "tokens · {} → {} ({} total)",
+            usage.input_tokens,
+            usage.output_tokens,
+            usage.total_tokens()
+        );
     }
 
     let output = match definition.validate_provider_output(response.as_str()) {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -18,7 +18,8 @@ pub(crate) use openai::{
     send_image_request as send_openai_image_request, send_request as send_openai_request,
 };
 pub(crate) use runtime::{
-    resolve_inputs as resolve_provider_inputs, Cargo as AgentCargo, ValidatedResponse,
+    resolve_inputs as resolve_provider_inputs, Cargo as AgentCargo, LlmReply, LlmUsage,
+    ValidatedResponse,
 };
 
 /// Default temperature used for model requests when not explicitly overridden.

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -212,7 +212,7 @@ async fn send_chat_completions_request(
     timeout_in_sec: u64,
     token: &String,
     response_format: serde_json::Value,
-) -> Result<String, ProviderError> {
+) -> Result<super::LlmReply, ProviderError> {
     let client = ClientBuilder::new()
         .timeout(Duration::from_secs(timeout_in_sec))
         .build()
@@ -272,7 +272,21 @@ async fn send_chat_completions_request(
     };
 
     match response.choices.first() {
-        Some(choice) => Ok(choice.message.content.clone()),
+        Some(choice) => {
+            // OpenAI always populates `usage` on a successful
+            // chat/completions response; we map zero into Some(0)
+            // rather than dropping the field, so downstream usage
+            // accounting stays accurate even on cached / replayed
+            // requests where the provider may return zeros.
+            let usage = super::LlmUsage {
+                input_tokens: u64::from(response.usage.prompt_tokens),
+                output_tokens: u64::from(response.usage.completion_tokens),
+            };
+            Ok(super::LlmReply {
+                text: choice.message.content.clone(),
+                usage: Some(usage),
+            })
+        }
         None => Err(ProviderError::invalid_response(
             ProviderKind::OpenAi,
             "No ChatGPT response choice at index 0.",
@@ -287,7 +301,7 @@ async fn send_chatgpt_codex_responses_request(
     timeout_in_sec: u64,
     token: &String,
     response_format: serde_json::Value,
-) -> Result<String, ProviderError> {
+) -> Result<super::LlmReply, ProviderError> {
     let client = ClientBuilder::new()
         .timeout(Duration::from_secs(timeout_in_sec))
         .build()
@@ -390,13 +404,17 @@ async fn send_chatgpt_codex_responses_request(
         }
     }
 
+    // The ChatGPT Codex Responses streaming protocol doesn't
+    // include a token-usage block on the events we currently
+    // consume, so we report `None`. A follow-up PR can wire it
+    // up once we add the `response.completed` summary parsing.
     if let Some(done) = completed_text {
-        return Ok(done);
+        return Ok(super::LlmReply { text: done, usage: None });
     }
 
     let fallback = accumulated_text.trim().to_string();
     if !fallback.is_empty() {
-        return Ok(fallback);
+        return Ok(super::LlmReply { text: fallback, usage: None });
     }
 
     Err(ProviderError::invalid_response(
@@ -526,7 +544,7 @@ pub async fn send_request(
     timeout_in_sec: u64,
     token: &String,
     response_format: serde_json::Value,
-) -> Result<String, ProviderError> {
+) -> Result<super::LlmReply, ProviderError> {
     if is_chatgpt_codex_responses_endpoint(url) {
         send_chatgpt_codex_responses_request(
             url,
@@ -765,10 +783,69 @@ mod tests {
             }
         });
 
-        let response = send_request(&url, &model, &content_parts, 10, &token, response_format)
+        let reply = send_request(&url, &model, &content_parts, 10, &token, response_format)
             .await
             .expect("stream response should parse");
-        assert_eq!(response, "{\"answer\":\"hi\"}");
+        assert_eq!(reply.text, "{\"answer\":\"hi\"}");
+        // The Codex Responses streaming path doesn't currently
+        // include a usage block on the events we consume — surface
+        // that as None rather than fabricating zeros.
+        assert!(reply.usage.is_none());
+    }
+
+    #[tokio::test]
+    async fn chat_completions_response_carries_token_usage() {
+        let mut server = mockito::Server::new_async().await;
+        // Minimal valid /v1/chat/completions response body with a
+        // populated `usage` block. The runtime should propagate the
+        // counts through LlmReply.usage.
+        let body = serde_json::json!({
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 1_700_000_000u64,
+            "model": "gpt-4o-mini",
+            "choices": [{
+                "index": 0,
+                "message": { "role": "assistant", "content": "{\"answer\":\"hi\"}" },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 412,
+                "completion_tokens": 89,
+                "total_tokens": 501
+            }
+        })
+        .to_string();
+
+        let _mock = server
+            .mock("POST", "/v1/chat/completions")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .create_async()
+            .await;
+
+        let url = format!("{}/v1/chat/completions", server.url());
+        let model = "gpt-4o-mini".to_string();
+        let content_parts = vec![ContentPart::Text("return json".to_string())];
+        let token = "test-token".to_string();
+        let response_format = serde_json::json!({
+            "type": "json_schema",
+            "json_schema": {
+                "name": "Output",
+                "schema": { "type": "object", "properties": { "answer": { "type": "string" } } },
+                "strict": true
+            }
+        });
+
+        let reply = send_request(&url, &model, &content_parts, 10, &token, response_format)
+            .await
+            .expect("chat completions response should parse");
+        assert_eq!(reply.text, "{\"answer\":\"hi\"}");
+        let usage = reply.usage.expect("usage should be present on OpenAI chat responses");
+        assert_eq!(usage.input_tokens, 412);
+        assert_eq!(usage.output_tokens, 89);
+        assert_eq!(usage.total_tokens(), 501);
     }
 
     #[tokio::test]

--- a/src/providers/runtime.rs
+++ b/src/providers/runtime.rs
@@ -13,6 +13,38 @@ pub(crate) enum ContentPart {
     File { filename: String, file_data: String },
 }
 
+/// Provider-neutral usage shape returned alongside an LLM reply.
+/// Counts are in tokens (input vs. output); both providers either
+/// emit these or omit them — wrap the call site in `Option<LlmUsage>`
+/// so missing data degrades cleanly.
+///
+/// Producers normalise their wire formats into this shape:
+/// OpenAI's `prompt_tokens` / `completion_tokens`, Ollama's
+/// `prompt_eval_count` / `eval_count`. Consumers (the runtime
+/// completion line, downstream cost estimation) don't care which
+/// provider answered.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LlmUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+}
+
+impl LlmUsage {
+    pub fn total_tokens(&self) -> u64 {
+        self.input_tokens.saturating_add(self.output_tokens)
+    }
+}
+
+/// Bundles an LLM reply with whatever usage metadata the provider
+/// returned. `usage` is `None` when the provider response omitted
+/// the field — common with older Ollama builds, custom-proxied
+/// OpenAI-compatible endpoints, etc.
+#[derive(Clone, Debug)]
+pub struct LlmReply {
+    pub text: String,
+    pub usage: Option<LlmUsage>,
+}
+
 pub(crate) trait ValidatedResponse {
     fn validate_response(&self) -> Result<(), String>;
 }
@@ -277,10 +309,49 @@ fn image_media_type(path: &Path) -> Result<&'static str, String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cargo, ContentPart, ValidatedResponse};
+    use super::{Cargo, ContentPart, LlmReply, LlmUsage, ValidatedResponse};
     use base64::Engine as _;
     use serde::{Deserialize, Serialize};
     use std::path::Path;
+
+    #[test]
+    fn llm_usage_total_tokens_sums_input_and_output() {
+        let u = LlmUsage {
+            input_tokens: 412,
+            output_tokens: 89,
+        };
+        assert_eq!(u.total_tokens(), 501);
+    }
+
+    #[test]
+    fn llm_usage_total_saturates_at_u64_max() {
+        // Defensive: a malformed provider response that reports
+        // absurd token counts shouldn't panic the runtime.
+        let u = LlmUsage {
+            input_tokens: u64::MAX,
+            output_tokens: 1,
+        };
+        assert_eq!(u.total_tokens(), u64::MAX);
+    }
+
+    #[test]
+    fn llm_reply_carries_optional_usage() {
+        let with_usage = LlmReply {
+            text: "hello".to_string(),
+            usage: Some(LlmUsage {
+                input_tokens: 10,
+                output_tokens: 4,
+            }),
+        };
+        assert_eq!(with_usage.text, "hello");
+        assert_eq!(with_usage.usage.unwrap().total_tokens(), 14);
+
+        let without_usage = LlmReply {
+            text: "hi".to_string(),
+            usage: None,
+        };
+        assert!(without_usage.usage.is_none());
+    }
 
     #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
     struct SampleOutput {


### PR DESCRIPTION
## Summary

Captures `prompt_tokens` + `completion_tokens` from the OpenAI chat/completions response and threads them through the runtime so they print between the existing `using:` line and the action graph:

```
using: profile=none auth=api_key server=openai model=gpt-4o-mini
run: sequential
tokens · 412 → 89 (501 total)
[Action 1: …] started
…
Run complete · 2.5s total
```

## Motivation

`ChatCompletionsResponse.usage` was already being deserialized — just discarded inside `send_chat_completions_request`, which only returned the choice text. Adopters running cargo-ai as a subprocess for cost accounting (CI cost budgets, hosted control planes that resell tokens) had to estimate from request bodies. This change exposes the number cargo-ai already saw.

## Wire changes

- **New shared types in `providers/runtime.rs`:**
  - `LlmUsage { input_tokens: u64, output_tokens: u64 }` — provider-neutral counts. `total_tokens()` saturates so a malformed provider response can't panic.
  - `LlmReply { text: String, usage: Option<LlmUsage> }` — bundles the reply with whatever usage metadata the provider returned. `usage` is `Option<>` so endpoints that don't expose counts (Codex Responses stream today, custom OpenAI-compatible proxies) report `None` instead of fabricated zeros.

- **`providers/openai.rs::send_request` now returns `Result<LlmReply, _>`:**
  - chat/completions path populates `usage: Some(…)` by mapping `prompt_tokens` → `input_tokens` and `completion_tokens` → `output_tokens`.
  - chatgpt-codex streaming responses path returns `usage: None` — the events we consume today don't carry usage; a follow-up can add it once we parse the `response.completed` summary.

- **`commands/runtime.rs`** captures the `LlmReply`, stores the optional `LlmUsage`, and prints the `tokens · A → B (T total)` line after the LLM call returns and before the action graph runs. Ordering means cost is observable even if a later action fails.

## Scope

OpenAI only. Ollama's `send_request` signature is unchanged — adding usage there is out of scope and can land independently once we settle on `prompt_eval_count` / `eval_count` (native Ollama) vs. OpenAI-compatible `usage` (Ollama's chat/completions shim) precedence.

## Test plan

- [x] `providers::runtime::tests::llm_usage_total_tokens_sums_input_and_output`
- [x] `providers::runtime::tests::llm_usage_total_saturates_at_u64_max` — defensive: malformed provider response can't panic.
- [x] `providers::runtime::tests::llm_reply_carries_optional_usage`
- [x] `providers::openai::tests::chat_completions_response_carries_token_usage` — mockito-backed end-to-end through `send_request`, asserts `LlmReply.usage` is populated with the right counts.
- [x] Existing `parses_chatgpt_codex_stream_done_payload` updated to assert `reply.text` + that the streaming path returns `usage: None`.

Full suite: 440/440 pass on this branch. There's one pre-existing flake in `commands::runtime_actions::tests::apply_actions_parallel_abort_stops_other_lanes_before_next_step` that reproduces on clean `upstream/develop` too — independent of this change.

## Use case

Companion to [#103](https://github.com/analyzer1/cargo-ai/pull/103) (`--emit-output`). Both came out of building [Tembo Agent Studio](https://github.com/tembo/agent-studio), a self-hosted control plane that runs cargo-ai as a subprocess. The dashboard wants to surface per-run cost; the only blocker was that cargo-ai discarded the count it had.