### PR TITLE
chore(release): prepare cargo-ai 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cargo-ai"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-ai"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT"
 description = "Build lightweight AI agents with Cargo. Powered by Rust. Declared in JSON."

--- a/README.md
+++ b/README.md
@@ -1148,6 +1148,7 @@ When you want deeper details, use these files:
 
 - Versioning and releases:
   - [VERSIONING.md](./VERSIONING.md)
+  - [releases/0.3.1.md](./releases/0.3.1.md)
   - [releases/0.3.0.md](./releases/0.3.0.md)
   - [releases/0.2.0.md](./releases/0.2.0.md)
 - Examples:

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -6,14 +6,14 @@ Cargo AI uses semantic versions as a product and CLI contract, not as a Rust lib
 
 While Cargo AI is in the `0.y.z` range, the leftmost non-zero digit is the main compatibility signal.
 
-- `0.y.0` means meaningful product and contract evolution across one or more public surfaces.
-- `0.y.z` means smaller bug fixes, polish, documentation updates, and low-risk compatibility improvements that should not materially change how users author, hatch, run, or share agents.
+- `0.y.z` means a compatible release on the same pre-`1.0.0` line. It may include bug fixes, polish, documentation updates, and additive capabilities that should not require users to rewrite existing agent definitions, CLI usage, generated agents, or project workflows.
+- `0.(y+1).0` means a new pre-`1.0.0` compatibility line. Cargo AI uses this for larger milestones, compatibility-boundary releases, or changes with meaningful migration risk.
 
 ## How To Read Releases
 
-- A release such as `0.1.1` should feel like a smaller follow-up release, not a major expansion of what authored agents or the CLI can do.
-- A release such as `0.2.0` signals that Cargo AI gained meaningful new capability or compatibility surface, even though the product is still pre-`1.0.0`.
-- While Cargo AI remains pre-`1.0.0`, generated-agent provenance/version checks stay intentionally exact. After a meaningful upgrade, existing hatched agents may report `out_of_sync` until they are re-hatched with the newer Cargo AI.
+- A release such as `0.3.1` should be compatible with the `0.3.0` line. It may add new optional behavior, but existing supported definitions and commands should keep working.
+- A release such as `0.4.0` signals a new pre-`1.0.0` compatibility line or a larger product milestone where users should read the release notes before assuming the same compatibility posture as `0.3.x`.
+- While Cargo AI remains pre-`1.0.0`, generated-agent provenance/version checks stay intentionally exact. After installing a newer Cargo AI, existing hatched agents may report `out_of_sync` until they are re-hatched with the newer Cargo AI, even when the release is otherwise compatible.
 
 ## Public Compatibility Surfaces
 
@@ -25,15 +25,15 @@ For Cargo AI, the compatibility surfaces that matter most are:
 - generated-agent behavior and embedded provenance/version expectations
 - documented authoring, account, and release-facing workflows that users are expected to follow
 
-Implementation details may change underneath those surfaces, but changes that materially affect them should be treated as contract changes rather than patch-level noise.
+Implementation details may change underneath those surfaces. Compatible additive changes may ship on the same `0.y.z` line, while breaking changes, migration-risky changes, or larger compatibility-boundary milestones should move to the next `0.(y+1).0` line.
 
 ## What 1.0.0 Means
 
 `1.0.0` should mean Cargo AI is ready to stand behind a stable core public contract across the surfaces above. That does not mean the product stops evolving. It means compatibility changes become rarer, more deliberate, and more tightly managed.
 
-## Why This Release Is 0.3.0
+## Current Release Line
 
-The `0.3.0` release is a pre-`1.0.0` contract release because Cargo AI has evolved meaningfully since `0.2.0` in user-visible ways, including:
+The `0.3.x` line began with the `0.3.0` pre-`1.0.0` contract release. That release introduced meaningful user-visible evolution since `0.2.0`, including:
 
 - direct interpreted execution with `cargo ai run`
 - inline and stdin definition sources for fast scripted authoring flows
@@ -44,7 +44,7 @@ The `0.3.0` release is a pre-`1.0.0` contract release because Cargo AI has evolv
 - structured tool parameter support for validated array and object values
 - install, Cargo AI Home, package, and release-facing documentation updates
 
-That is larger than a patch-level `0.2.1` release, but it is not yet a `1.0.0` stability promise.
+Compatible additive releases on the `0.3.x` line can build on that baseline without signaling a new compatibility boundary. The next `0.4.0` release is reserved for a larger milestone, a compatibility-boundary release, or a change with meaningful migration risk.
 
 ## Upgrade Guidance
 

--- a/releases/0.3.1.md
+++ b/releases/0.3.1.md
@@ -1,0 +1,55 @@
+# cargo-ai 0.3.1
+
+## Compatibility
+
+- Ship this as a compatible additive release on the `0.3.x` line.
+- No intentional breaking changes are included.
+- Keep `0.4.0` reserved for a later milestone, compatibility-boundary release, or migration-risky change.
+
+## Image Generation
+
+- Add `generate_image.reference_images` so image-generation steps can use one or more reference images.
+- Support `{ "input": "<named image input>" }` for declared top-level image inputs and `{ "path": "./assets/reference.png" }` for definition-owned local image assets.
+- Preserve reference-image order so prompts can distinguish the primary source or edit-target image from supporting style, detail, color, or material references.
+- Keep local reference paths constrained to the current level or below; absolute paths and parent traversal are rejected.
+
+## Provider Behavior
+
+- Route OpenAI API-key image reference requests through the OpenAI image edit/reference-image path.
+- Include reference images as Responses image input parts for OpenAI account-backed image generation.
+- Fail clearly when `reference_images` is used with Ollama-backed `generate_image`, because the current Ollama compatibility path remains prompt-only.
+
+## Usage Ledger
+
+- Add an opt-in run-scoped usage ledger through `--usage-log <path>` and `CARGO_AI_USAGE_LOG=<path>`.
+- Write newline-delimited JSON events for root runs, agent runs, provider requests, tool runs, and completion boundaries.
+- Normalize provider-reported usage into `input_tokens`, `output_tokens`, and `total_tokens` when OpenAI or Ollama reports counters.
+- Propagate the same `root_run_id` through direct child agents and tool-bridge-launched child agents, while each agent execution keeps its own `agent_run_id` and `parent_agent_run_id`.
+- Keep usage events metadata-only by default: no raw prompts, model output text, generated image bytes, tool payloads, or profile secrets are written.
+
+## Guidance And Docs
+
+- Refresh the README opening around declarative AI agents shipped as local CLI apps.
+- Update README, schema quick reference, Codex guidance, and examples for reference images and usage-ledger behavior.
+- Add generated Codex guidance for usage-ledger activation, NDJSON/JSONL event shape, tree-aware attribution, and metadata-only logging boundaries.
+- Let `cargo ai add guidance --style codex` install `.cargo-ai/guidance/` when a user-owned root `AGENTS.md` already exists, while preserving that existing file and printing a merge snippet.
+
+## Public Notes
+
+- Existing supported `0.3.0` definitions and commands are expected to keep working.
+- Existing hatched agents may still report `out_of_sync` because Cargo AI's generated-agent provenance checks are exact. Re-hatch agents when you want their embedded Cargo AI version and generated templates to match `0.3.1`.
+- The rolling Windows preview artifact remains separate from stable versioned releases and is currently unsigned.
+
+## Upgrade
+
+```bash
+cargo install cargo-ai --locked
+```
+
+To check whether a newer crates.io version is available:
+
+```bash
+cargo ai version --check
+```
+
+See [VERSIONING.md](../VERSIONING.md) for the public versioning policy.


### PR DESCRIPTION
- bump Cargo AI package and lockfile versions to 0.3.1
- add 0.3.1 release notes and link them from the README
- clarify pre-1.0 compatible additive release policy for the 0.3.x line

Related to: CAI-2099